### PR TITLE
chore: release 1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.1] - 2026-05-24
+
+### Added
+- **Csi/UI port — batch 1/4** (primitives from PowerACC):
+  - `helpers/windowHelper.ts` — `isSmallDevice()` responsive media-query check.
+  - `helpers/processQueryButtons.ts` — `addProcessQueryButtons()` factory for paired Query/Clear toolbar buttons.
+  - `types/gridEditableMode.ts` — `GridEditableMode` discriminated union (`Full` / `Off` / `Some`).
+  - `formatters/formatterHelper.ts` — `customerCodeFormatter`, `isNumericTemplate`, `isNumericInput` (filename fixes the original `Formater` typo).
+- 22 new unit tests covering the three modules above.
+
 ## [1.1.0] - 2026-05-23
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@idevs/corelib",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Extended library components and utilities for Serenity Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
Version bump + CHANGELOG entry for the Csi/UI port batch 1 (merged in #2).

- `package.json`: 1.1.0 → 1.1.1
- `CHANGELOG.md`: new 1.1.1 section listing the four new primitive modules and 22 new tests

Merging this triggers the Release workflow which will publish `@idevs/corelib@1.1.1` to npm via OIDC Trusted Publishing.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm test -- --run` — 50/50 passing
- [ ] Post-merge: Release workflow publishes 1.1.1 with SLSA provenance