### PR TITLE
chore: pin glob to ^11.1.0 via npm overrides (CVE-2025-64756)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@idevs/corelib",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@idevs/corelib",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.33.0",
@@ -1459,6 +1459,31 @@
         "glob": "11.0.3"
       }
     },
+    "node_modules/@serenity-is/tsbuild/node_modules/glob": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
+      "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "foreground-child": "^3.3.1",
+        "jackspeak": "^4.1.1",
+        "minimatch": "^10.1.1",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -2632,31 +2657,6 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
-    "node_modules/glob": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.3.tgz",
-      "integrity": "sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "foreground-child": "^3.3.1",
-        "jackspeak": "^4.1.1",
-        "minimatch": "^10.0.3",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^2.0.0"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/glob-parent": {

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
   },
   "overrides": {
     "@serenity-is/tsbuild": {
-      "glob": "^11.1.0"
+      "glob": "11.1.0"
     }
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -75,6 +75,9 @@
       "optional": true
     }
   },
+  "overrides": {
+    "glob": "^11.1.0"
+  },
   "devDependencies": {
     "@eslint/js": "^9.33.0",
     "@serenity-is/corelib": "^8.8.6",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,9 @@
     }
   },
   "overrides": {
-    "glob": "^11.1.0"
+    "@serenity-is/tsbuild": {
+      "glob": "^11.1.0"
+    }
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",


### PR DESCRIPTION
## Summary

Closes Dependabot alert [#21](https://github.com/klomkling/idevs.corelib/security/dependabot/21) (CVE-2025-64756, CVSS 7.5 high).

Adds an `overrides` entry in `package.json` forcing the transitive `glob` devDependency (pulled in via `@serenity-is/tsbuild@8.8.8`) to **^11.1.0**, which contains the patch.

### Why this is safe
- The vulnerability is in glob's **CLI** (`glob -c <command>` shell injection). This project never invokes the glob CLI — `@serenity-is/tsbuild` uses the library API only, which is unaffected.
- Override pinned to `^11.1.0` (not `>=`) so glob stays within tsbuild's expected major version (verified: `^11` resolves to `11.1.0`, not the latest 13.x).

### Verification
- `npm audit` — 0 vulnerabilities
- `npm ls glob` — `glob@11.1.0` selected
- `npm run typecheck` — clean
- `npm run lint` — clean (1 pre-existing warning)
- `npm test -- --run` — 50/50 passing
- `npm run build` — success (this exercises tsbuild + glob, confirming runtime compatibility with the patched version)

### Suggested merge order
This is independent of PR #4 (editors batch 2). Merging this first means the next release (1.1.2 with batch 2) ships with the security fix bundled. CHANGELOG entry deferred to that release PR.