### PR TITLE
feat: port Csi/UI dialogs + panels foundation (batch 4/4 — PR 4a)

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -48,9 +48,11 @@ All in `src/panels/`, exported from the public barrel.
 - `ShippingMarkEntityDialog`, `ShippingMarkPanel` — PowerACC's shipping-mark module.
 - The PowerACC-domain types from `Dialogs.ts`: `NameValueCollection`, `RequestApprovalDetailParameter`, `IvnRequestApprovalDetailParameter`, `BookingRequestApprovalDetailParameter`, `RequestApprovalParameter`, `RequestOnedateReportParameter`, `InventoryRequestApprovalParameter`, `BookingRequestApprovalParameter`, `RequestPrintShippingMarkParameter`. These reference `@/ServerTypes/Sales/ApprovalRequestRow` and similar — domain code stays in PowerACC.
 
-### Breaking API renames
+### API additions (PascalCase setters preserved as compatibility shims)
 
-- PowerACC's PascalCase assignment-style setters (`dialog.FilterKeys = ...`, `dialog.CriteriaKeys = ...`, `dialog.DialogSize = ...`) are replaced with camelCase methods on dialogs: `setFilterKeys()`, `setCriteriaKeys()`, `setDialogSize()`, `setDialogType()`, `setDialogPermission()`, `setPreItems()`.
+- Dialogs now expose **camelCase methods** as the preferred API: `setFilterKeys()`, `setCriteriaKeys()`, `setSearchValue()`, `setDialogSize()`, `setDialogType()`, `setDialogPermission()`, `setPreItems()`.
+- The PowerACC **PascalCase assignment setters** (`dialog.FilterKeys = ...`, `dialog.CriteriaKeys = ...`, `dialog.SearchValue = ...`, `dialog.DialogSize = ...`, `dialog.DialogType = ...`, `dialog.DialogPermission = ...`, `dialog.preItems = ...`) **are preserved as compatibility shims** that route to the camelCase methods. Existing callers (notably `IdevsSearchButtonEditor.openDialog`, which still writes by assignment per the PowerACC dialog interface contract) continue to work unchanged. Subclass overrides of the camelCase methods take effect through either entry point.
+- New consumer code should prefer the camelCase methods. The PascalCase shims are not deprecated in this release but may be in a future major bump — track via the project changelog.
 - `IdevsInlineDialog.IdevsCustomButton.style` and `IdevsInlineDialog.IdevsEmptyField.style` no longer accept a raw CSS-string variant (CSS-injection vector) — use `Partial<CSSStyleDeclaration>` only.
 - `CsiPanel.PanelTitle` / `CsiPanel.Fields` getters/setters → `IdevsPanel.title` + `IdevsPanel.setTitle()` + `IdevsPanel.getFields()` + `IdevsPanel.setFields()`.
 - Clone-mode marker `__csiCloneMode` → `__idevsCloneMode`. Consumers that inspect this marker directly need to migrate (rare — typically only `isCloneMode()` users).

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -29,9 +29,11 @@ All in `src/panels/`, exported from the public barrel.
   element.createLayout(3, 'col')
 
   // idevs.corelib:
-  import { createLayout } from '@idevs/corelib/helpers'
+  import { createLayout } from '@idevs/corelib'
   createLayout(element, 3, 'col')
   ```
+
+  Note: helpers are re-exported from the main `@idevs/corelib` barrel — there is no separate `@idevs/corelib/helpers` subpath in `package.json#exports`. Use the root import.
 
   Affected functions: `createLayout`, `addElementGroup`, `createGroup`, `addElements`, `addElementsWithEmptyElement`, `setTabIndex`, `groupColumnHeader`.
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,83 @@
 # Migration Guide
 
+## 1.3.x → 1.4.0 — batch 4a dialog/panel foundation
+
+### New dialog classes
+
+All in `src/dialogs/`, exported from the public barrel.
+
+- `IdevsPropertyDialog` (decorator: `Idevs.CoreLib.IdevsPropertyDialog`) — replaces PowerACC's `CsiPropertyDialog`. Extends Serenity `PropertyDialog`; integrates with modal-stack helpers; dispatches `onDialogClose` CustomEvent.
+- `IdevsEntityDialog` (decorator: `Idevs.CoreLib.IdevsEntityDialog`) — replaces PowerACC's `CsiEntityDialog`. Adds dirty-check confirm-on-close, clone mode (`__idevsCloneMode` marker, renamed from `__csiCloneMode`), and a custom close button.
+- `IdevsInlineDialog` (decorator: `Idevs.CoreLib.IdevsInlineDialog`) — replaces PowerACC's `CsiInlineDialog`. Embeds an EntityDialog inline (non-modal) with custom buttons + empty field slots.
+- `IdevsSearchDialog` (decorator: `Idevs.CoreLib.IdevsSearchDialog`) — replaces PowerACC's `CsiSearchDialog`. Abstract base for search-result dialogs with grid integration + clear/new toolbar buttons.
+
+### New panel classes
+
+All in `src/panels/`, exported from the public barrel.
+
+- `IdevsPage` (decorator: `Idevs.CoreLib.IdevsPage`) — replaces PowerACC's `CsiPage`. Page-level container; no preact dependency (source used `render(<CsiTitle/>)`; ported with plain DOM).
+- `IdevsPanel` (decorator: `Idevs.CoreLib.IdevsPanel`) — replaces PowerACC's `CsiPanel`. Field-rendering container with label + input pairs.
+- `IdevsOffcanvasPanel` (decorator: `Idevs.CoreLib.IdevsOffcanvasPanel`) — replaces PowerACC's `OffCanvasPanel`. Bootstrap offcanvas slide-out hosting an EntityDialog.
+- `IdevsTabControl` (decorator: `Idevs.CoreLib.IdevsTabControl`) — replaces PowerACC's `CsiTabControl`. Bootstrap tabs with full WAI-ARIA wiring.
+
+### New helpers
+
+- `src/helpers/layoutHelper.ts` — 21 DOM/layout utilities ported from PowerACC's `LayoutHelper.ts`. **Behavioral change**: the source attached 7 of these as `HTMLElement.prototype` methods; they are now plain functions:
+
+  ```ts
+  // PowerACC:
+  element.createLayout(3, 'col')
+
+  // idevs.corelib:
+  import { createLayout } from '@idevs/corelib/helpers'
+  createLayout(element, 3, 'col')
+  ```
+
+  Affected functions: `createLayout`, `addElementGroup`, `createGroup`, `addElements`, `addElementsWithEmptyElement`, `setTabIndex`, `groupColumnHeader`.
+
+  Note: `layoutHelper.ts`'s async polling `getElementHeight` is re-exported as `waitForElementHeight` to disambiguate from `utils/dom.ts`'s synchronous variant.
+
+- `src/helpers/filterHelper.ts` — `clearFilter(filters)` ported from PowerACC's `FilterHelper.ts`.
+
+- `src/helpers/dialogHelpers.ts` (plural — new file, leaves existing `dialogHelper.ts` untouched) — generic dialog/modal helpers from PowerACC's `Dialogs.ts`. Exports: `setDialogSize`, `fixMobileCloseDialog`, `groupFields`, `setActiveModal`, `setInactiveModal`, `disableRadioButtons`, `enableRadioButtons`, `enableRadioButtonEditor`, `disableRadioButtonEditor`, `enableEditor`, `disableEditor`, `disableToolbarButton`, `enableToolbarButton`, `toggleInputValidateMessage`, `addSearchButton`, `SearchDialogOptions`, `IdevsDialogEventName`, `createCustomEvent`.
+
+### NOT ported (stay in PowerACC)
+
+- `ShippingMarkEntityDialog`, `ShippingMarkPanel` — PowerACC's shipping-mark module.
+- The PowerACC-domain types from `Dialogs.ts`: `NameValueCollection`, `RequestApprovalDetailParameter`, `IvnRequestApprovalDetailParameter`, `BookingRequestApprovalDetailParameter`, `RequestApprovalParameter`, `RequestOnedateReportParameter`, `InventoryRequestApprovalParameter`, `BookingRequestApprovalParameter`, `RequestPrintShippingMarkParameter`. These reference `@/ServerTypes/Sales/ApprovalRequestRow` and similar — domain code stays in PowerACC.
+
+### Breaking API renames
+
+- PowerACC's PascalCase assignment-style setters (`dialog.FilterKeys = ...`, `dialog.CriteriaKeys = ...`, `dialog.DialogSize = ...`) are replaced with camelCase methods on dialogs: `setFilterKeys()`, `setCriteriaKeys()`, `setDialogSize()`, `setDialogType()`, `setDialogPermission()`, `setPreItems()`.
+- `IdevsInlineDialog.IdevsCustomButton.style` and `IdevsInlineDialog.IdevsEmptyField.style` no longer accept a raw CSS-string variant (CSS-injection vector) — use `Partial<CSSStyleDeclaration>` only.
+- `CsiPanel.PanelTitle` / `CsiPanel.Fields` getters/setters → `IdevsPanel.title` + `IdevsPanel.setTitle()` + `IdevsPanel.getFields()` + `IdevsPanel.setFields()`.
+- Clone-mode marker `__csiCloneMode` → `__idevsCloneMode`. Consumers that inspect this marker directly need to migrate (rare — typically only `isCloneMode()` users).
+- `IdevsPanel`'s editor factory no longer special-cases `CsiDateEditor` for the `format: 'd/m/Y'` default. Consumers using `IdevsDateEditor` (which lives at the `@idevs/corelib/editors/idevsDateEditor` subpath because of its optional `flatpickr` peer dep) must set `format: 'd/m/Y'` explicitly in their `editorOptions`.
+
+### Hardening deltas vs PowerACC source
+
+- **Security**: XSS-safe label markup in `IdevsPanel` and `toggleInputValidateMessage` (DOM API + `textContent` + `createElement('sup')` — replaces the source's raw HTML-property writes on form labels). `IdevsOffcanvasPanel`'s titlebar copy uses `replaceChildren(cloneNode())` instead of raw markup copy.
+- **Resource hygiene**: `IdevsEntityDialog`'s `beforeunload` window listener is now stored and removed in `destroy()` (source registered without cleanup — leak across dialog lifetimes).
+- **Async correctness**: `IdevsEntityDialog`'s close-button handler replaces source's `setInterval(100ms)` polling for `_canClose` with a Promise that resolves when the flag flips. Debug `console.log("Waiting for flag")` removed.
+- **No-console policy**: `console.log/error` debug spam removed from `IdevsOffcanvasPanel`. `LayoutHelper`'s Thai-language `console.error` logs replaced with silent fail.
+- **ARIA additions**: `IdevsOffcanvasPanel` now has `role="dialog"` + `aria-modal="true"` (source had aria-labelledby but no role/aria-modal). `IdevsTabControl` already had complete ARIA in source — preserved.
+- **Type quality**: `any` → `unknown` or proper generics throughout; structural types replace untyped Serenity casts in `IdevsInlineDialog`'s dialog-internals access and `IdevsPanel`'s editor-instance reads.
+- **`saveDialogForm` refactor**: replaced the `new Promise(async ...)` executor with direct `async/await` + a leaf Promise for the save callback (ESLint `no-async-promise-executor` compliance).
+
+### Public barrel changes
+
+```ts
+// src/index.ts after 1.4.0
+export * from './editors'
+export * from './dialogs'    // NEW
+export * from './formatters'
+export * from './panels'     // NEW
+export * from './ui'
+export * from './helpers'    // EXTENDED — adds dialogHelpers, filterHelper, layoutHelper
+export * from './utils'
+export * from './types'
+```
+
 ## 1.2.x → 1.3.0 — batch 3b self-search button editor
 
 ### New editors

--- a/docs/superpowers/specs/2026-05-26-batch-4-dialogs-panels-grids-design.md
+++ b/docs/superpowers/specs/2026-05-26-batch-4-dialogs-panels-grids-design.md
@@ -1,0 +1,348 @@
+# Batch 4 — Csi/UI Dialogs, Panels, Grids: Design
+
+**Date:** 2026-05-26
+**Status:** Approved (pending user review of this spec)
+**Source:** `~/GitHub/Proj_PowerACC/PowerACC.Web/Modules/Csi/UI/`
+**Target:** `@idevs/corelib` v1.3.0 → 1.5.0 (three minors, one per PR)
+
+## 1. Scope
+
+Port the dialog/panel/grid infrastructure from PowerACC's `Csi/UI` module into `@idevs/corelib`, applying the same hardening rigor batches 2-3 established (XSS-safe DOM, full WAI-ARIA, idempotent `destroy()`, narrow types, single-chokepoint patterns).
+
+**Excluded** — domain-specific code that stays in PowerACC:
+- `ShippingMarkEntityDialog.ts` (226) and `ShippingMarkPanel.ts` (157) — PowerACC's shipping-mark module.
+- Half of `Dialogs.ts` (~240 LOC) — PowerACC parameter types (`RequestApprovalParameter`, `BookingRequestApprovalParameter`, `RequestPrintShippingMarkParameter`, etc.) that pull from `@/ServerTypes/Sales/...`. The PowerACC-domain types stay in PowerACC.
+
+**In scope** (~4,947 LOC, 18 files):
+
+| Category | Files | LOC |
+|---|---|---|
+| Dialog shells | `CsiInlineDialog`, `CsiEntityDialog`, `CsiPropertyDialog`, `CsiSearchDialog`, `Dialogs.ts` (generic half) | ~1,180 |
+| Panel shells | `CsiPanel`, `OffcanvasPanel`, `CsiTabControl`, `CsiPage` | ~602 |
+| Helpers | `LayoutHelper`, `Buttons`, `FilterHelper` | ~541 |
+| Grid extensions | `CsiGridEditorBase`, `GridEditController`, `CsiSearchGrid`, `CsiSelectableEntityGrid`, `CsiEntityGrid` | ~1,573 |
+| Filter panel | `CsiFilterPanel` | ~1,048 |
+
+## 2. PR sequence (three PRs)
+
+### PR-4a — Foundation (~2,300 LOC)
+
+Dialog shells + Panel shells + small helpers. Sequenced first because PR-4b depends on the dialog/panel base classes.
+
+### PR-4b — Grid extensions (~1,570 LOC)
+
+`IdevsGridEditorBase`, `IdevsGridEditController`, `IdevsSearchGrid`, `IdevsSelectableEntityGrid`, `IdevsEntityGrid`. Depends on PR-4a's dialogs/panels.
+
+### PR-4c — Filter panel (~1,063 LOC)
+
+`IdevsFilterPanel` (decomposed from the source's 1,048-LOC single file). Depends on PR-4b's grid extensions.
+
+## 3. Naming conventions
+
+- **`Idevs` prefix on all classes** registered as Serenity widgets (carries `@Decorators.registerClass()`). Decorator strings: `Idevs.CoreLib.Idevs*` where the source used `Csi.*`.
+- Helpers (pure functions in `src/helpers/`) keep camelCase filenames with no class prefix.
+- `Csi` → `Idevs` rename mapped per file in the table at section 5 below.
+
+## 4. Hardening (carries forward from batches 2-3)
+
+Same rigor applied across all new code:
+
+- Plain `type` for options (no `EditorProps<any>` or interface extension).
+- `unknown` not `any` throughout; structural-type constraints where source had `(x as any)` casts.
+- XSS-safe DOM construction — no `innerHTML` writes; all text via `textContent`.
+- Full WAI-ARIA where applicable: `role="dialog"` + `aria-modal` + `aria-labelledby` on dialogs; `role="tablist"`/`role="tab"`/`role="tabpanel"` + arrow-key nav on `IdevsTabControl`; `role="grid"` on grid extensions.
+- Focus restoration on dialog close (matches `SearchModalController` precedent — return focus to the invoker).
+- Listener cleanup tracked in a per-instance array; drained idempotently in `destroy()`.
+- Per-render listener separation where re-renders happen (modal/dropdown precedent).
+- Single-chokepoint discipline where value writes occur (relevant in `IdevsPanel`'s field-binding paths).
+- Deferred-focus timers cancelled on close/destroy (precedent from `searchModal`/`searchDropdown`).
+- Async race guards on any future `fetchResults`-style flows.
+
+## 5. File mapping (Csi → Idevs)
+
+| PowerACC source | idevs.corelib target | PR |
+|---|---|---|
+| `CsiInlineDialog.ts` | `src/dialogs/idevsInlineDialog.ts` | 4a |
+| `CsiEntityDialog.ts` | `src/dialogs/idevsEntityDialog.ts` | 4a |
+| `CsiPropertyDialog.ts` | `src/dialogs/idevsPropertyDialog.ts` | 4a |
+| `CsiSearchDialog.tsx` | `src/dialogs/idevsSearchDialog.ts` | 4a |
+| `Dialogs.ts` (generic exports) | `src/helpers/dialogHelper.ts` (EXTENDED) | 4a |
+| `CsiPanel.tsx` | `src/panels/idevsPanel.ts` | 4a |
+| `OffcanvasPanel.ts` | `src/panels/idevsOffcanvasPanel.ts` | 4a |
+| `CsiTabControl.ts` | `src/panels/idevsTabControl.ts` | 4a |
+| `CsiPage.tsx` | `src/panels/idevsPage.ts` | 4a |
+| `LayoutHelper.ts` | `src/helpers/layoutHelper.ts` | 4a |
+| `Buttons.ts` | `src/helpers/buttons.ts` | 4a |
+| `FilterHelper.ts` | `src/helpers/filterHelper.ts` | 4a |
+| `CsiGridEditorBase.ts` | `src/grids/idevsGridEditorBase.ts` | 4b |
+| `GridEditController.ts` | `src/grids/idevsGridEditController.ts` | 4b |
+| `CsiSearchGrid.tsx` | `src/grids/idevsSearchGrid.ts` | 4b |
+| `CsiSelectableEntityGrid.ts` | `src/grids/idevsSelectableEntityGrid.ts` (evaluate merge) | 4b |
+| `CsiEntityGrid.ts` | `src/grids/idevsEntityGrid.ts` (evaluate drop) | 4b |
+| `CsiFilterPanel.tsx` | `src/filterPanel/idevsFilterPanel.ts` (+ internal subdir) | 4c |
+
+## 6. PR-4a detailed architecture
+
+### 6.1 `src/dialogs/`
+
+#### `idevsEntityDialog.ts`
+
+```ts
+@Decorators.registerClass()
+export class IdevsEntityDialog<TItem, P = unknown> extends EntityDialog<TItem, P> {
+  protected confirmMessage: string
+  protected canClose(): boolean
+  protected setCanClose(value: boolean): void
+
+  protected enterCloneMode(): void
+  protected exitCloneMode(): void
+  protected isCloneMode(): boolean
+
+  protected customEvent: CustomEvent
+}
+```
+
+Dirty-check confirm-before-close + clone-mode ("Save As") workflows extracted as protected hooks.
+
+**Hardening**: drop `any` for `initialEntity` (use `TItem` generic). Verify `aria-modal` is applied on dialog open and override if Serenity's base class doesn't already.
+
+#### `idevsInlineDialog.ts`
+
+```ts
+export type IdevsCustomButton = {
+  id: string
+  text: string
+  columnCssClass?: string
+  cssClass?: string
+  style?: Partial<CSSStyleDeclaration>   // string variant dropped (CSS-injection vector)
+  click?: (e: Event) => void
+  afterField?: string
+}
+
+export type IdevsEmptyField = {
+  columnCssClass?: string
+  cssClass?: string
+  style?: Partial<CSSStyleDeclaration>
+  afterField?: string
+}
+
+export type IdevsInlineDialogCallbacks = {
+  onSave?: (entity: unknown) => void
+  onCancel?: () => void
+  onChange?: (entity: unknown) => void
+}
+
+@Decorators.registerClass()
+export class IdevsInlineDialog<TItem, P = unknown> extends EntityDialog<TItem, P> {
+  addCustomButton(button: IdevsCustomButton): void
+  addEmptyField(field: IdevsEmptyField): void
+}
+```
+
+**Hardening**: `Partial<CSSStyleDeclaration> | string` → object only (the string variant in the source allowed arbitrary CSS injection). Editor references updated to `IdevsDateEditor` (already in main via batch 2).
+
+#### `idevsPropertyDialog.ts`
+
+~80 LOC port. Extends Serenity's `PropertyDialog`. Adds shared lifecycle hooks for dialog sizing + open/close instrumentation.
+
+#### `idevsSearchDialog.ts`
+
+```ts
+@Decorators.registerClass()
+export class IdevsSearchDialog<TRow = Record<string, unknown>, P = unknown>
+  extends EntityDialog<TRow, P> {
+  FilterKeys?: Record<string, unknown>
+  CriteriaKeys?: unknown[]
+  SearchValue?: string
+  preItems?: TRow[]
+
+  dialogOpen(): void
+  protected emitSelection(row: TRow): void   // dispatches dataSelected CustomEvent
+}
+```
+
+This is the production implementation of the dialog `IdevsSearchButtonEditor` resolves via `searchDialogType`. PR-3a's tests use a stub; PR-4a ships the real class. Consumers extend `IdevsSearchDialog<TRow>` for typed rows.
+
+### 6.2 `src/panels/`
+
+#### `idevsPanel.ts`
+
+```ts
+export type IdevsPanelFieldOptions = {
+  type: 'string' | 'number' | 'decimal' | 'enum' | 'lookup' | 'serviceLookup' | 'date' | 'search' | 'selfSearch'
+  name: string
+  title?: string
+  required?: boolean
+  readOnly?: boolean
+  // ... per-type config
+}
+
+export type IdevsPanelOptions = {
+  title?: string
+  fields: IdevsPanelFieldOptions[]
+  columns?: number
+  // ... layout config
+}
+
+@Decorators.registerClass()
+export class IdevsPanel<P extends IdevsPanelOptions = IdevsPanelOptions> extends Widget<P> {
+  // Field-rendering container that delegates to Serenity's built-in editors
+  // (StringEditor, DecimalEditor, EnumEditor, LookupEditor, ServiceLookupEditor)
+  // plus the Idevs editor family (IdevsDateEditor, IdevsSearchButtonEditor,
+  // IdevsSelfSearchButtonEditor, IdevsTagEditor, IdevsNumericTagEditor).
+}
+```
+
+**Hardening**: explicit field-type discriminated union (no string-typed `type` field). Unknown editor type throws a clear error at construction (not silent no-op). ARIA: `<label for>`/`<input id>` pairing for every field.
+
+#### `idevsOffcanvasPanel.ts`
+
+Bootstrap offcanvas wrapper. **Hardening**: full ARIA dialog pattern matching `SearchModalController`'s focus discipline — `role="dialog"`, `aria-modal`, `aria-labelledby`, focus capture on open, focus restoration to invoker on close, Escape closes.
+
+#### `idevsTabControl.ts`
+
+Bootstrap tab wrapper. **Hardening**: full WAI-ARIA tab pattern — `role="tablist"` + `role="tab"` + `aria-selected` + `aria-controls`, `role="tabpanel"` + `aria-labelledby`, arrow-key navigation (Left/Right) between tabs with `tabindex` management. Optional `aria-orientation` for vertical tablists.
+
+#### `idevsPage.ts`
+
+Structural container. Minimal hardening surface (no value writes, no dialog lifecycle).
+
+### 6.3 `src/helpers/` additions
+
+- `layoutHelper.ts` — pure DOM/layout utilities ported from `LayoutHelper.ts`. Each function unit-testable in isolation. Likely contents: column splits, breakpoint detection, sticky-element positioning, viewport calculations.
+- `buttons.ts` — toolbar button factory functions. Strip PowerACC-specific button presets (anything referencing approval/booking/shipping marks).
+- `filterHelper.ts` — filter-criteria utilities.
+- `dialogHelper.ts` (EXTENDED) — merge in generic exports from PowerACC's `Dialogs.ts`: `fixMobileCloseDialog`, `setDialogSize`, `groupFields`, `setActiveModal`, `setInactiveModal`, `disableRadioButtons`, `enableRadioButtons`, `enableRadioButtonEditor`, `addSearchButton<F>`, `SearchDialogOptions<F>`.
+
+### 6.4 Public barrel updates (PR-4a)
+
+```ts
+// src/index.ts after PR-4a
+export * from './editors'
+export * from './formatters'
+export * from './helpers'
+export * from './types'
+export * from './ui'
+export * from './utils'
+export * from './dialogs'   // NEW
+export * from './panels'    // NEW
+```
+
+## 7. PR-4b architecture (provisional — detailed at port time)
+
+```
+src/grids/
+├── idevsGridEditorBase.ts                  (~1,000 LOC after hardening)
+├── idevsGridEditController.ts              (~410 LOC)
+├── idevsSearchGrid.ts                      (~180 LOC)
+├── idevsSelectableEntityGrid.ts            (~30 LOC; evaluate merge with idevsSearchGrid)
+├── idevsEntityGrid.ts                      (~15 LOC; evaluate drop entirely)
+└── index.ts
+```
+
+- `IdevsGridEditorBase` will get the same decomposition treatment as `IdevsSelfSearchButtonEditor` if it exceeds 600 LOC after hardening — internal helpers extracted to `src/grids/internal/`.
+- `IdevsGridEditController` extracted as a controller class (constructor-injected callbacks, no back-reference to grid) — same pattern as `SearchModalController`.
+- `IdevsSelectableEntityGrid` (21 LOC) and `IdevsEntityGrid` (10 LOC) evaluated at port time for net value vs consumers extending Serenity's `EntityGrid` directly.
+
+**Hardening focus**: narrow SleekGrid's `any`-heavy editing APIs via structural constraints (`SlickWrappedEditor` precedent). Listener lifecycle matching the modal/dropdown discipline.
+
+## 8. PR-4c architecture (provisional)
+
+```
+src/filterPanel/
+├── idevsFilterPanel.ts                     (~600-700 LOC main class after decomposition)
+├── internal/
+│   ├── filterFieldRenderers.ts             (per-type field rendering)
+│   ├── filterStateManager.ts               (criteria serialization)
+│   └── filterEvents.ts                     (apply/clear/save events)
+└── index.ts
+```
+
+The source `CsiFilterPanel.tsx` is 1,048 LOC — decomposed the same way `IdevsSelfSearchButtonEditor` was (main class + internal subdir + controllers).
+
+PR-4c depends on PR-4b's `IdevsSearchGrid` for lookup-field popovers and on PR-4a's `IdevsPanel`/`IdevsTabControl` for layout.
+
+## 9. Testing strategy
+
+**PR-4a target: ~80-100 tests**
+
+- Dialog smoke per class — construction, ARIA wiring, dirty-check confirm flow (IdevsEntityDialog), custom button registration (IdevsInlineDialog), search-result emission (IdevsSearchDialog).
+- Panel smoke — field-rendering routes correctly to each editor, options propagation, idempotent destroy.
+- TabControl — ARIA tab pattern, arrow-key navigation.
+- Helper unit tests — `layoutHelper` ~30 tests for pure helpers, `buttons`, `filterHelper`.
+- New: `tests/_helpers/dialogTestUtils.ts` for shared dialog mount/unmount helpers.
+
+**PR-4b target: ~60-80 tests**
+
+- `IdevsGridEditorBase` via a `TestableGridEditor` fixture pattern (analog to `TestableSlickEditor` from batch 3).
+- `IdevsGridEditController` state-machine tests with mocked SlickGrid.
+- `IdevsSearchGrid` row selection + filter pipe through to dialog callbacks.
+
+**PR-4c target: ~50-70 tests**
+
+- Field-renderer purity tests per field type.
+- Criteria-state manager round-trip (serialize → deserialize identity).
+- IdevsFilterPanel smoke: apply/clear/save flows, ARIA, destroy cleanup.
+
+**Total across batch 4: ~200 new tests.**
+
+## 10. Test infrastructure
+
+- Reuse existing `tests/editors/_helpers/searchDialogStub.ts` for backwards-compat tests.
+- Add `tests/_helpers/dialogTestUtils.ts` — common dialog mount/unmount helpers, modal-stack assertions.
+- Add `tests/_helpers/serviceCallStub.ts` if any new dialog/grid talks to Serenity services (currently only the editor tests use this).
+
+## 11. MIGRATION.md updates (per PR)
+
+### PR-4a section
+
+- New `src/dialogs/` and `src/panels/` directories with public barrels.
+- `Csi*` → `Idevs*` renames for `InlineDialog`, `EntityDialog`, `PropertyDialog`, `SearchDialog`, `Panel`, `OffcanvasPanel`, `TabControl`, `Page`.
+- New helpers: `layoutHelper`, `buttons`, `filterHelper`.
+- Extended `dialogHelper.ts` gains the generic exports from `Dialogs.ts`.
+- **Dialogs.ts's PowerACC-domain types are NOT ported** — consumers keep `ApprovalRequestRow`/`BookingApprovalRequestRow`/`RequestPrintShippingMarkParameter`/etc. locally in PowerACC. Editor-reference ripple from batches 2-3 means PowerACC's existing `Csi*` editor imports should already be migrated.
+- `IdevsInlineDialog.IdevsCustomButton.style` and `IdevsEmptyField.style` no longer accept a `string` variant (CSS-injection vector); use the `Partial<CSSStyleDeclaration>` form.
+
+### PR-4b section
+
+- New `src/grids/` directory with public barrel.
+- `Csi*` → `Idevs*` renames for `GridEditorBase`, `GridEditController`, `SearchGrid`. `SelectableEntityGrid` and `EntityGrid` may be merged/dropped at port time (will be documented when finalized).
+- `IdevsGridEditorBase`'s `TEditor` generic now constrained by `SlickWrappedEditor`-style structural type.
+
+### PR-4c section
+
+- New `src/filterPanel/` directory with public barrel; internal subdir not exported.
+- `Csi*` → `Idevs*` rename for `FilterPanel`.
+
+## 12. Risks and trade-offs
+
+1. **Serenity dialog lifecycle quirks** — `EntityDialog` has subtle subclass contracts (`loadEntity` ordering, `onDialogOpen` timing). Mitigation: each dialog gets a smoke test driving the full open → load → save → close cycle.
+
+2. **`Dialogs.ts` callsites in PowerACC** — PowerACC's existing `import {setDialogSize} from '@/Csi'` will need to switch to `import {setDialogSize} from '@idevs/corelib/helpers'` once PR-4a ships. Documented in MIGRATION.md; the function bodies are identical.
+
+3. **CsiFilterPanel internal coupling unknown** — at 1,048 LOC the actual decomposition boundaries can only be confirmed by reading the file. PR-4c design is provisional and will be revised at port time.
+
+4. **`IdevsGridEditorBase` SleekGrid-internal patterns unknown** — same caveat as #3. PR-4b design provisional.
+
+5. **Public-barrel surface growing** — after batch 4, the main barrel exports become substantial. Follow-up: formalize subpath exports per directory (`@idevs/corelib/dialogs`, `@idevs/corelib/panels`, `@idevs/corelib/grids`, `@idevs/corelib/filterPanel`). Out of scope for batch 4; tracked.
+
+6. **Editor reference updates** — PowerACC's dialog/panel sources reference `CsiDateEditor`, `SearchButtonEditor`, `SelfSearchButtonEditor`, `TagEditor`. The port substitutes our `Idevs*` versions (already in main via batches 2-3).
+
+7. **`style: string` removal in IdevsInlineDialog** — minor breaking change. Consumers passing a raw CSS string can migrate by parsing to an object. Documented.
+
+## 13. Out of scope (follow-ups)
+
+- ShippingMark* port (PowerACC keeps these as domain code).
+- PowerACC-domain parameter types from `Dialogs.ts` (kept in PowerACC).
+- Subpath exports per directory (`@idevs/corelib/dialogs` etc.).
+- Result virtualization in any new grid surfaces (if needed) — separate effort.
+- Real focus trap on dialogs (PR-3b deferred this; could be implemented in batch 4 if a clean reusable helper emerges, otherwise still deferred).
+
+## 14. Acceptance criteria (per PR)
+
+- All four CI steps pass: typecheck, lint, test, build.
+- No `EditorProps<any>` or new `any` types in new code.
+- All dialogs have a passing ARIA smoke test (role / aria-modal / aria-labelledby).
+- Idempotent `destroy()` verified for every new dialog/panel via a regression test.
+- MIGRATION.md section for the PR.
+- Public barrel exports the new top-level modules; internal subdirs (`src/filterPanel/internal/`, `src/grids/internal/` if it exists) are NOT exported publicly.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -37,6 +37,7 @@ export default [
         HTMLButtonElement: 'readonly',
         Element: 'readonly',
         ChildNode: 'readonly',
+        BeforeUnloadEvent: 'readonly',
         HTMLHeadingElement: 'readonly',
         HTMLTableElement: 'readonly',
         HTMLTableSectionElement: 'readonly',

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -35,6 +35,8 @@ export default [
         HTMLImageElement: 'readonly',
         HTMLLabelElement: 'readonly',
         HTMLButtonElement: 'readonly',
+        Element: 'readonly',
+        ChildNode: 'readonly',
         HTMLHeadingElement: 'readonly',
         HTMLTableElement: 'readonly',
         HTMLTableSectionElement: 'readonly',

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -44,6 +44,7 @@ export default [
         HTMLTableSectionElement: 'readonly',
         HTMLTableRowElement: 'readonly',
         HTMLTableCellElement: 'readonly',
+        HTMLUListElement: 'readonly',
         HTMLSelectElement: 'readonly',
         HTMLTextAreaElement: 'readonly',
         HTMLSpanElement: 'readonly',

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -38,6 +38,7 @@ export default [
         Element: 'readonly',
         ChildNode: 'readonly',
         BeforeUnloadEvent: 'readonly',
+        CSS: 'readonly',
         HTMLHeadingElement: 'readonly',
         HTMLTableElement: 'readonly',
         HTMLTableSectionElement: 'readonly',

--- a/src/dialogs/idevsEntityDialog.ts
+++ b/src/dialogs/idevsEntityDialog.ts
@@ -3,6 +3,7 @@ import {
   Decorators,
   EntityDialog,
   Fluent,
+  notifyError,
   type SaveResponse,
   type ToolButton,
   tryFirst,
@@ -31,9 +32,13 @@ import { setActiveModal, setInactiveModal } from '../helpers/dialogHelpers'
  *   - `setInterval(100ms)` polling in the close-button handler replaced
  *     with a Promise that resolves when `_canClose` flips.
  *   - `onDialogClose` confirmDialog reordering: the source dispatched the
- *     close event BEFORE the user could respond to "save unsaved changes?"
- *     — this port keeps the original order (confirmDialog fires; close
- *     proceeds) but documents the limitation. Full async refactor deferred.
+ *     close event BEFORE the user could respond to "save unsaved changes?",
+ *     which let the dialog close out from under the user. This port FIXES
+ *     that — `onDialogClose` now blocks on the prompt via the
+ *     `_userConfirmedClose` flag and only proceeds via the prompt's button
+ *     handlers (`onYes-then-save-success` or `onNo-discard`). The Esc/
+ *     backdrop close paths route through the same gate as the custom
+ *     close-button click.
  */
 @Decorators.registerClass('Idevs.CoreLib.IdevsEntityDialog')
 export class IdevsEntityDialog<TItem, P = unknown> extends EntityDialog<TItem, P> {
@@ -237,10 +242,17 @@ export class IdevsEntityDialog<TItem, P = unknown> extends EntityDialog<TItem, P
       confirmDialog(
         this.confirmMessage,
         () => {
-          // User chose "yes, save". Save runs; ONLY on success do we
-          // set the confirmed flag and close the dialog. If save fails
-          // (validation, service error) the success callback is never
-          // invoked — the dialog stays open with the unsaved-changes
+          // User chose "yes, save". Run validation first — if the form is
+          // invalid, surface a notifyError so the user knows why the close
+          // didn't proceed (Serenity's inline validation also fires, but
+          // it's easy to miss when focus is on the prompt button).
+          if (!this.validateBeforeSave()) {
+            notifyError('Save failed — please review the form for validation errors.')
+            return
+          }
+          // ONLY on save success do we set the confirmed flag and close.
+          // If save fails (service error post-validation) the callback
+          // never fires — the dialog stays open with the unsaved-changes
           // state intact, so the next close attempt re-prompts.
           this.save(() => {
             this._userConfirmedClose = true
@@ -391,11 +403,18 @@ export class IdevsEntityDialog<TItem, P = unknown> extends EntityDialog<TItem, P
     }, 0)
   }
 
+  /** Max time waitForCanClose will poll before giving up (defensive cap). */
+  private static readonly CAN_CLOSE_MAX_WAIT_MS = 5_000
+
   private waitForCanClose(): Promise<void> {
     // Replaces the source's `setInterval(100ms)` polling. Resolves
     // immediately if _canClose is already true; otherwise polls quietly.
     // Interval handle stored on the instance so destroy() can clear it
     // (otherwise a never-flipping _canClose would leak the interval forever).
+    // Bounded by CAN_CLOSE_MAX_WAIT_MS — protects against a subclass
+    // override of updateInterface that throws before the snapshot timer
+    // resets _canClose, which would otherwise leave the interval running
+    // until destroy.
     return new Promise(resolve => {
       if (this._canClose) {
         resolve()
@@ -403,14 +422,11 @@ export class IdevsEntityDialog<TItem, P = unknown> extends EntityDialog<TItem, P
       }
       // Clear any prior polling interval — only one waiter at a time.
       if (this._canClosePollId !== undefined) clearInterval(this._canClosePollId)
+      const startedAt = Date.now()
       this._canClosePollId = setInterval(() => {
-        if (this._isDestroyed) {
-          if (this._canClosePollId !== undefined) clearInterval(this._canClosePollId)
-          this._canClosePollId = undefined
-          resolve()
-          return
-        }
-        if (this._canClose) {
+        const elapsed = Date.now() - startedAt
+        const done = this._isDestroyed || this._canClose || elapsed >= IdevsEntityDialog.CAN_CLOSE_MAX_WAIT_MS
+        if (done) {
           if (this._canClosePollId !== undefined) clearInterval(this._canClosePollId)
           this._canClosePollId = undefined
           resolve()
@@ -433,10 +449,17 @@ export class IdevsEntityDialog<TItem, P = unknown> extends EntityDialog<TItem, P
       confirmDialog(
         this.confirmMessage,
         () => {
-          // Save AND close — set the confirmed flag and close ONLY after
-          // save succeeds. A failed save (validation, service error)
-          // leaves _userConfirmedClose false, so the next close attempt
-          // re-prompts instead of silently discarding the dirty edits.
+          // Validate FIRST; surface a notifyError if invalid so the user
+          // sees concrete feedback at the close-attempt level (Serenity's
+          // inline errors also fire but can be missed when focus is on
+          // the prompt). On validation pass, save; on save success
+          // (callback fires), set the confirmed flag + close.
+          if (!this.validateBeforeSave()) {
+            notifyError('Save failed — please review the form for validation errors.')
+            // Restore modal layering since the close was cancelled.
+            this.restoreActiveModal()
+            return
+          }
           this.save(() => {
             this._userConfirmedClose = true
             this.dialogClose('save-and-close')
@@ -451,9 +474,26 @@ export class IdevsEntityDialog<TItem, P = unknown> extends EntityDialog<TItem, P
           },
         },
       )
-      this.restoreActiveModal()
+      // NOTE: restoreActiveModal moved into the prompt callbacks above
+      // (review round 10 fix). The previous unconditional restore here
+      // ran synchronously AFTER queueing the async confirmDialog,
+      // undoing the inactive-modal layering before the user saw the
+      // prompt. Now restoration happens only when the prompt resolves
+      // (yes-validate-fail path; the yes-save-success path goes through
+      // dialogClose, which triggers a fresh onDialogClose → restore).
     } else {
       this.dialogClose('save-and-close')
     }
+  }
+
+  /**
+   * Pre-save validation guard. Override in subclasses for custom checks.
+   * Defaults to invoking Serenity's standard validateForm() if present;
+   * returns true (let save proceed) when the validator isn't available.
+   */
+  protected validateBeforeSave(): boolean {
+    const self = this as unknown as { validateForm?: () => boolean }
+    if (typeof self.validateForm === 'function') return self.validateForm()
+    return true
   }
 }

--- a/src/dialogs/idevsEntityDialog.ts
+++ b/src/dialogs/idevsEntityDialog.ts
@@ -31,14 +31,15 @@ import { setActiveModal, setInactiveModal } from '../helpers/dialogHelpers'
  *     lifetimes on long-running sessions).
  *   - `setInterval(100ms)` polling in the close-button handler replaced
  *     with a Promise that resolves when `_canClose` flips.
- *   - `onDialogClose` confirmDialog reordering: the source dispatched the
- *     close event BEFORE the user could respond to "save unsaved changes?",
- *     which let the dialog close out from under the user. This port FIXES
- *     that — `onDialogClose` now blocks on the prompt via the
- *     `_userConfirmedClose` flag and only proceeds via the prompt's button
- *     handlers (`onYes-then-save-success` or `onNo-discard`). The Esc/
- *     backdrop close paths route through the same gate as the custom
- *     close-button click.
+ *   - Dirty-close gating: the source ran its confirm prompt async from
+ *     within onDialogClose (the AFTER-close hook), which meant the dialog
+ *     was already hidden by the time the user saw the prompt. This port
+ *     uses Serenity's provider-abstracted `onClose(..., { before: true })`
+ *     API — the right preventable event for whichever provider hosts the
+ *     dialog (hide.bs.modal for Bootstrap modals, panelbeforeclose for
+ *     panels, dialogbeforeclose for jQuery UI dialogs). All close paths
+ *     (Esc, backdrop, programmatic dialogClose, custom X button) route
+ *     through one centralized confirm flow in showDirtyCloseConfirm().
  */
 @Decorators.registerClass('Idevs.CoreLib.IdevsEntityDialog')
 export class IdevsEntityDialog<TItem, P = unknown> extends EntityDialog<TItem, P> {
@@ -54,18 +55,12 @@ export class IdevsEntityDialog<TItem, P = unknown> extends EntityDialog<TItem, P
   private _isDestroyed = false
   /**
    * Tracks whether the user has already responded to the unsaved-changes
-   * confirm prompt for the current close attempt. The hide.bs.modal
-   * before-close listener (setupBeforeCloseGate) checks this flag and
-   * preventDefault's the close when it's false AND the form is dirty.
+   * confirm prompt for the current close attempt. The before-close
+   * handler (registered via Serenity's onClose(..., { before: true }))
+   * checks this flag and preventDefault's the close when it's false AND
+   * the form is dirty.
    */
   private _userConfirmedClose = false
-  /**
-   * The Bootstrap modal element (the `.modal` wrapper around domNode)
-   * that we attach the hide.bs.modal listener to. Captured at open time
-   * for clean detach in destroy().
-   */
-  private _modalEl?: HTMLElement
-  private _beforeCloseHandler?: (e: Event) => void
 
   private _confirmMessage = 'You have unsaved changes. Do you want to save before closing?'
   get confirmMessage(): string {
@@ -125,6 +120,48 @@ export class IdevsEntityDialog<TItem, P = unknown> extends EntityDialog<TItem, P
     const handler = this.handleBeforeUnload.bind(this)
     this._beforeUnloadHandler = handler
     window.addEventListener('beforeunload', handler)
+
+    // Register the before-close dirty-check guard via Serenity's
+    // provider-abstracted onClose API. With `{ before: true }` this maps
+    // to the right preventable event for each dialog provider:
+    //   - Bootstrap modal  → hide.bs.modal
+    //   - panel            → panelbeforeclose
+    //   - jQuery UI dialog → dialogbeforeclose
+    // The raw `hide.bs.modal` listener used in the prior round only
+    // covered the modal path — panel-mode dialogs (dialogOpen(true))
+    // had no before-close listener installed, so dirty closes silently
+    // discarded changes. `oneOff: false` keeps the callback registered
+    // across the lifetime of this instance.
+    this.registerBeforeCloseGate()
+  }
+
+  private registerBeforeCloseGate(): void {
+    // `onClose` is inherited from Serenity's Dialog base. Treat the
+    // signature defensively via a structural cast — the typings on
+    // EntityDialog don't surface it consistently across Serenity
+    // versions, but the runtime API is stable.
+    const self = this as unknown as {
+      onClose?(
+        callback: (result?: string, e?: Event) => void,
+        options?: { before?: boolean; oneOff?: boolean },
+      ): void
+    }
+    if (typeof self.onClose !== 'function') return
+    self.onClose(
+      (result, e) => {
+        if (this._isDestroyed) return
+        if (this._userConfirmedClose) return
+        if (!this.hasUnsavedChanges()) return
+        // Prevent the close — modal stays visible / panel stays open /
+        // jQuery UI dialog stays open. The prompt's onYes / onNo
+        // callbacks set _userConfirmedClose and re-trigger dialogClose,
+        // which fires this same handler; on the second pass the flag
+        // short-circuits and the close proceeds.
+        e?.preventDefault()
+        this.showDirtyCloseConfirm(result)
+      },
+      { before: true, oneOff: false },
+    )
   }
 
   override destroy(): void {
@@ -141,7 +178,10 @@ export class IdevsEntityDialog<TItem, P = unknown> extends EntityDialog<TItem, P
       clearInterval(this._canClosePollId)
       this._canClosePollId = undefined
     }
-    this.teardownBeforeCloseGate()
+    // The before-close handler registered via onClose() doesn't need
+    // explicit detach — Serenity's Dialog lifecycle disposes its own
+    // subscribers on destroy. The _isDestroyed guard inside the
+    // callback handles any post-destroy invocation defensively.
     super.destroy()
   }
 
@@ -170,79 +210,18 @@ export class IdevsEntityDialog<TItem, P = unknown> extends EntityDialog<TItem, P
     this.cloneButton?.toggle(this.isEditMode())
 
     this.initCloseButtonHandler()
-    this.setupBeforeCloseGate()
     setInactiveModal(this.domNode)
 
     super.onDialogOpen()
   }
 
   /**
-   * Register the Bootstrap `hide.bs.modal` before-close listener that
-   * gates Esc / backdrop / programmatic close paths on the dirty-check
-   * prompt.
-   *
-   * Why a before-close listener rather than the inherited
-   * `onDialogClose` override: Serenity's `onDialogClose` is invoked from
-   * the AFTER-close hook (the modal is already hiding when it fires).
-   * Returning early from `onDialogClose` does NOT keep the modal
-   * visible. The confirm prompt would appear over a hidden modal and
-   * the user could end up with an orphaned dialog state. Bootstrap's
-   * `hide.bs.modal` fires BEFORE the hide animation and respects
-   * `preventDefault()` — that's what we need to actually gate the
-   * close.
-   *
-   * Flow:
-   *   1. User presses Esc / clicks backdrop / calls `dialogClose()`.
-   *   2. Bootstrap dispatches `hide.bs.modal`.
-   *   3. Our handler fires: if not yet confirmed AND dirty,
-   *      `e.preventDefault()` (modal stays open) and show the confirm
-   *      prompt.
-   *   4. Prompt's onYes-save-success or onNo-discard callback sets
-   *      `_userConfirmedClose = true` then calls `dialogClose()`.
-   *   5. Bootstrap re-dispatches `hide.bs.modal`; our handler sees the
-   *      flag and lets the close proceed.
-   *   6. After Bootstrap finishes hiding, `onDialogClose` runs and
-   *      dispatches `customEvent` + cleanup. The flag is reset there
-   *      for the next open.
-   */
-  private setupBeforeCloseGate(): void {
-    // Deferred — Serenity's modal wrapper may not be in the DOM yet at
-    // the moment onDialogOpen fires. setTimeout(0) lets the mount settle.
-    setTimeout(() => {
-      if (this._isDestroyed) return
-      const modal = this.domNode.closest<HTMLElement>('.modal')
-      if (!modal) return
-
-      // Replace any prior wiring (defensive — onDialogOpen runs on every
-      // open of a reused dialog instance).
-      this.teardownBeforeCloseGate()
-
-      const handler = (e: Event) => {
-        if (this._userConfirmedClose) return
-        if (!this.hasUnsavedChanges()) return
-        e.preventDefault()
-        this.showDirtyCloseConfirm()
-      }
-      modal.addEventListener('hide.bs.modal', handler)
-      this._modalEl = modal
-      this._beforeCloseHandler = handler
-    }, 0)
-  }
-
-  private teardownBeforeCloseGate(): void {
-    if (this._modalEl && this._beforeCloseHandler) {
-      this._modalEl.removeEventListener('hide.bs.modal', this._beforeCloseHandler)
-    }
-    this._modalEl = undefined
-    this._beforeCloseHandler = undefined
-  }
-
-  /**
-   * Show the confirm prompt for an unsaved-changes close attempt. Used
-   * by both the before-close gate (setupBeforeCloseGate) and the
-   * custom close button (onCloseButtonClick). Both paths route through
-   * this single implementation so the user only ever sees ONE prompt
-   * spelling and `_userConfirmedClose` is set in one place per outcome.
+   * Show the confirm prompt for an unsaved-changes close attempt. The
+   * before-close handler registered in the constructor (via Serenity's
+   * provider-abstracted onClose API) calls this when the close attempt
+   * is blocked. The prompt's button handlers set the confirmed flag and
+   * re-trigger dialogClose, which re-enters the before-close handler
+   * with the flag set so the close passes through.
    */
   private showDirtyCloseConfirm(result?: string): void {
     confirmDialog(
@@ -355,7 +334,6 @@ export class IdevsEntityDialog<TItem, P = unknown> extends EntityDialog<TItem, P
     // fresh payload or fall back to an empty {}.
     this.customEvent = undefined
     this.restoreActiveModal()
-    this.teardownBeforeCloseGate()
     this._userConfirmedClose = false // reset for next open
     super.onDialogClose(result)
   }

--- a/src/dialogs/idevsEntityDialog.ts
+++ b/src/dialogs/idevsEntityDialog.ts
@@ -283,7 +283,13 @@ export class IdevsEntityDialog<TItem, P = unknown> extends EntityDialog<TItem, P
     const current = currentEntity as Record<string, unknown>
     const initial = initialEntity as Record<string, unknown>
 
-    return Object.keys(current).every(key => {
+    // Compare the UNION of keys, not just the current entity's. Without
+    // the symmetric check, a key that existed in `initial` but is missing
+    // from `current` (deletion / clear-to-undefined) would be skipped and
+    // hasUnsavedChanges would silently miss the change.
+    const allKeys = new Set<string>([...Object.keys(current), ...Object.keys(initial)])
+
+    for (const key of allKeys) {
       const currentValue = current[key]
       const initialValue = initial[key]
 
@@ -307,8 +313,11 @@ export class IdevsEntityDialog<TItem, P = unknown> extends EntityDialog<TItem, P
         initialValue !== null &&
         JSON.stringify(currentValue) === JSON.stringify(initialValue)
 
-      return currentValue === initialValue || bothNaN || bothDates || bothNullish || bothObjects
-    })
+      const equal =
+        currentValue === initialValue || bothNaN || bothDates || bothNullish || bothObjects
+      if (!equal) return false
+    }
+    return true
   }
 
   private handleBeforeUnload(event: BeforeUnloadEvent): void {

--- a/src/dialogs/idevsEntityDialog.ts
+++ b/src/dialogs/idevsEntityDialog.ts
@@ -265,7 +265,15 @@ export class IdevsEntityDialog<TItem, P = unknown> extends EntityDialog<TItem, P
 
     // No unsaved changes, or the user already confirmed — proceed.
     if (!this.customEvent) this.setCustomEvent({})
-    this.element[0].dispatchEvent(this.customEvent!)
+    const evt = this.customEvent!
+    this.element[0].dispatchEvent(evt)
+    // Clear the customEvent after dispatch — without this, a reused
+    // dialog instance can replay stale `detail` from a prior close (e.g.,
+    // a subclass called setCustomEvent during a save flow, then the user
+    // opens + closes again without triggering a fresh setCustomEvent).
+    // Reset forces the next close to either set a fresh payload or fall
+    // back to an empty {}.
+    this.customEvent = undefined
     this.restoreActiveModal()
     this._userConfirmedClose = false // reset for next open
     super.onDialogClose(result)

--- a/src/dialogs/idevsEntityDialog.ts
+++ b/src/dialogs/idevsEntityDialog.ts
@@ -6,6 +6,7 @@ import {
   type SaveResponse,
   type ToolButton,
   tryFirst,
+  type WidgetProps,
 } from '@serenity-is/corelib'
 import { setActiveModal, setInactiveModal } from '../helpers/dialogHelpers'
 
@@ -103,8 +104,12 @@ export class IdevsEntityDialog<TItem, P = unknown> extends EntityDialog<TItem, P
     }
   }
 
-  constructor() {
-    super()
+  constructor(props?: WidgetProps<P>) {
+    // Forward props to Serenity's EntityDialog so caller-supplied options
+    // (element, dialog-specific settings) take effect. The PowerACC source
+    // dropped this argument, ignoring any consumer options — a real bug
+    // that breaks any non-default instantiation.
+    super(props as WidgetProps<P>)
     const handler = this.handleBeforeUnload.bind(this)
     this._beforeUnloadHandler = handler
     window.addEventListener('beforeunload', handler)
@@ -159,12 +164,22 @@ export class IdevsEntityDialog<TItem, P = unknown> extends EntityDialog<TItem, P
   protected override updateInterface(): void {
     super.updateInterface()
 
-    // Delay the snapshot until the form has finished its async loading.
-    // The PowerACC source used a hard 2-second timeout — fragile but load
-    // timings vary, so we preserve it as a documented constraint.
-    // Timer handle stored so destroy() can cancel it (otherwise the
-    // callback would run against a torn-down dialog and throw).
+    // Take an IMMEDIATE snapshot so hasUnsavedChanges always has a baseline
+    // to compare against. Without this, the 2-second delay opened a window
+    // where the user could type AND close (Esc/backdrop) without seeing
+    // a confirm prompt — Esc/backdrop paths invoke hasUnsavedChanges
+    // directly without waiting on _canClose like the custom close button.
+    this.initialEntity = this.getSaveEntity() as TItem
     this._canClose = false
+
+    // Schedule a re-snapshot at +2s to cover async load paths that
+    // populate the form after updateInterface returns. The re-snapshot
+    // overwrites the immediate one — IF the user typed during the first
+    // 2 seconds, their edits become part of the new baseline (this is a
+    // known limitation; consumers needing dirty-tracking on async forms
+    // should override updateInterface and snapshot when their load
+    // promise resolves).
+    // Timer handle stored so destroy() can cancel it.
     if (this._initialSnapshotTimer !== undefined) {
       clearTimeout(this._initialSnapshotTimer)
     }
@@ -252,11 +267,9 @@ export class IdevsEntityDialog<TItem, P = unknown> extends EntityDialog<TItem, P
   }
 
   public hasUnsavedChanges(): boolean {
-    // Treat the pre-snapshot window (initialEntity not yet populated, e.g.,
-    // immediately after open or during the 2-second loadEntity delay) as
-    // "no changes". Without this guard, beforeunload prompts and
-    // confirm-on-close dialogs fire spuriously the moment the user opens
-    // the dialog. Real edits never start before the snapshot exists.
+    // initialEntity is populated synchronously in updateInterface, so a
+    // null value here means hasUnsavedChanges was called before the
+    // dialog finished mounting — treat as "no changes" defensively.
     if (this.initialEntity == null) return false
     const currentEntity = this.getSaveEntity()
     return !this.areEntitiesEqual(currentEntity, this.initialEntity)
@@ -322,12 +335,20 @@ export class IdevsEntityDialog<TItem, P = unknown> extends EntityDialog<TItem, P
     // _canClose + hasUnsavedChanges. Deferred so we run after Serenity
     // mounts the modal header.
     setTimeout(() => {
+      if (this._isDestroyed) return
+
       let closeButton = this.element.parent().findFirst('.btn-close')
       if (!closeButton[0]) closeButton = this.element.parent().findFirst('.panel-titlebar-close')
 
       closeButton.style(css => {
         css.display = 'none'
       })
+
+      // Remove any previously-injected .btn-close-x from prior opens of
+      // this dialog instance — onDialogOpen runs every open, so without
+      // this guard we'd stack a new button + handler on every reopen.
+      const existing = this.element.parent().findFirst('.btn-close-x')
+      if (existing[0]) existing.remove()
 
       const btn = document.createElement('button')
       btn.setAttribute('type', 'button')

--- a/src/dialogs/idevsEntityDialog.ts
+++ b/src/dialogs/idevsEntityDialog.ts
@@ -169,7 +169,12 @@ export class IdevsEntityDialog<TItem, P = unknown> extends EntityDialog<TItem, P
   protected override onSaveSuccess(response: SaveResponse): void {
     super.onSaveSuccess(response)
     this.initialEntity = this.getSaveEntity() as TItem
+    // Dispatch both casings to bridge the PowerACC source bug: source's
+    // IdevsEntityDialog dispatched onDataChange (camelCase) but
+    // OffCanvasPanel listened for ondatachange (lowercase). Keeping both
+    // makes either spelling work for downstream consumers during migration.
     this.element[0].dispatchEvent(new Event('onDataChange'))
+    this.element[0].dispatchEvent(new Event('ondatachange'))
   }
 
   protected override onDialogClose(result?: string): void {
@@ -190,6 +195,12 @@ export class IdevsEntityDialog<TItem, P = unknown> extends EntityDialog<TItem, P
   }
 
   public hasUnsavedChanges(): boolean {
+    // Treat the pre-snapshot window (initialEntity not yet populated, e.g.,
+    // immediately after open or during the 2-second loadEntity delay) as
+    // "no changes". Without this guard, beforeunload prompts and
+    // confirm-on-close dialogs fire spuriously the moment the user opens
+    // the dialog. Real edits never start before the snapshot exists.
+    if (this.initialEntity == null) return false
     const currentEntity = this.getSaveEntity()
     return !this.areEntitiesEqual(currentEntity, this.initialEntity)
   }
@@ -238,8 +249,14 @@ export class IdevsEntityDialog<TItem, P = unknown> extends EntityDialog<TItem, P
   }
 
   private restoreActiveModal(): void {
-    const modal = this.domNode.closest('.modal')
-    const currentLevel = parseInt(Fluent(modal as HTMLElement).data('qrouterorder') ?? '0', 10)
+    // Guard against detached DOM (closest can return null when the dialog
+    // is being torn down or used in a non-modal context).
+    const modal = this.domNode.closest<HTMLElement>('.modal')
+    if (!modal) {
+      setActiveModal(0)
+      return
+    }
+    const currentLevel = parseInt(Fluent(modal).data('qrouterorder') ?? '0', 10)
     setActiveModal(currentLevel)
   }
 

--- a/src/dialogs/idevsEntityDialog.ts
+++ b/src/dialogs/idevsEntityDialog.ts
@@ -1,0 +1,308 @@
+import {
+  confirmDialog,
+  Decorators,
+  EntityDialog,
+  Fluent,
+  type SaveResponse,
+  type ToolButton,
+  tryFirst,
+} from '@serenity-is/corelib'
+import { setActiveModal, setInactiveModal } from '../helpers/dialogHelpers'
+
+/**
+ * Entity-dialog wrapper that adds:
+ *   1. Unsaved-changes confirm-on-close (`hasUnsavedChanges` deep-compares
+ *      the current form state against an initial snapshot).
+ *   2. Clone mode ("Save As") via the `__idevsCloneMode` marker on the
+ *      cloned entity.
+ *   3. Custom close button with explicit ARIA label.
+ *   4. Modal-stack integration via setActiveModal/setInactiveModal.
+ *
+ * Replaces PowerACC's `CsiEntityDialog`. Migrated marker rename:
+ * `__csiCloneMode` → `__idevsCloneMode`.
+ *
+ * Hardening vs source:
+ *   - `initialEntity: any` → `TItem | null` with proper generic propagation.
+ *   - `console.log('Waiting for flag to be true')` removed (lint warning).
+ *   - `window.beforeunload` listener stored for removal in `destroy()`
+ *     (source registered it but never removed — memory leak across dialog
+ *     lifetimes on long-running sessions).
+ *   - `setInterval(100ms)` polling in the close-button handler replaced
+ *     with a Promise that resolves when `_canClose` flips.
+ *   - `onDialogClose` confirmDialog reordering: the source dispatched the
+ *     close event BEFORE the user could respond to "save unsaved changes?"
+ *     — this port keeps the original order (confirmDialog fires; close
+ *     proceeds) but documents the limitation. Full async refactor deferred.
+ */
+@Decorators.registerClass('Idevs.CoreLib.IdevsEntityDialog')
+export class IdevsEntityDialog<TItem, P = unknown> extends EntityDialog<TItem, P> {
+  private static readonly cloneModeMarker = '__idevsCloneMode'
+
+  private initialEntity: TItem | null = null
+  protected customEvent?: CustomEvent
+  private _canClose = true
+  private _isCloned = false
+  private _beforeUnloadHandler?: (event: BeforeUnloadEvent) => void
+
+  private _confirmMessage = 'You have unsaved changes. Do you want to save before closing?'
+  get confirmMessage(): string {
+    return this._confirmMessage
+  }
+  set confirmMessage(value: string) {
+    this._confirmMessage = value
+  }
+
+  private _confirmTitle = 'Confirm'
+  get confirmTitle(): string {
+    return this._confirmTitle
+  }
+  set confirmTitle(value: string) {
+    this._confirmTitle = value
+  }
+
+  private _alwaysDisableUndelete = true
+  get alwaysDisableUndelete(): boolean {
+    return this._alwaysDisableUndelete
+  }
+  set alwaysDisableUndelete(value: boolean) {
+    this._alwaysDisableUndelete = value
+  }
+
+  private _alwaysDisableLocalization = true
+  get alwaysDisableLocalization(): boolean {
+    return this._alwaysDisableLocalization
+  }
+  set alwaysDisableLocalization(value: boolean) {
+    this._alwaysDisableLocalization = value
+  }
+
+  get originalEntity(): TItem {
+    return this.entity
+  }
+
+  set isCloned(value: boolean) {
+    this._isCloned = value
+  }
+
+  get dialogMode(): { isNew: boolean; isEditMode: boolean; isCloneMode: boolean; isDeleted: boolean } {
+    return {
+      isNew: this.isNew(),
+      isEditMode: this.isEditMode(),
+      isCloneMode: this.isCloneMode(),
+      isDeleted: this.isDeleted(),
+    }
+  }
+
+  constructor() {
+    super()
+    const handler = this.handleBeforeUnload.bind(this)
+    this._beforeUnloadHandler = handler
+    window.addEventListener('beforeunload', handler)
+  }
+
+  override destroy(): void {
+    if (this._beforeUnloadHandler) {
+      window.removeEventListener('beforeunload', this._beforeUnloadHandler)
+      this._beforeUnloadHandler = undefined
+    }
+    super.destroy()
+  }
+
+  protected isCloneMode(): boolean {
+    const entity = this.entity as Record<string, unknown> | undefined
+    return (
+      this._isCloned === true ||
+      (this.isNew() && entity?.[IdevsEntityDialog.cloneModeMarker] === true)
+    )
+  }
+
+  protected override getCloningEntity(): TItem {
+    const clone = super.getCloningEntity() as TItem
+    ;(clone as Record<string, unknown>)[IdevsEntityDialog.cloneModeMarker] = true
+    return clone
+  }
+
+  protected override onDialogOpen(): void {
+    this.localizerButton?.hide()
+    this.undeleteButton?.hide()
+    this.cloneButton?.toggle(this.isEditMode())
+
+    this.initCloseButtonHandler()
+    setInactiveModal(this.domNode)
+
+    super.onDialogOpen()
+  }
+
+  protected setCustomEvent(detail: unknown): void {
+    this.customEvent = new CustomEvent('onDialogClose', { detail })
+  }
+
+  protected override updateInterface(): void {
+    super.updateInterface()
+
+    // Delay closing until the form has finished its async loading. The
+    // PowerACC source used a hard 2-second timeout — fragile but
+    // load timings vary, so we preserve it as a documented constraint.
+    this._canClose = false
+    setTimeout(() => {
+      this.initialEntity = this.getSaveEntity() as TItem
+      this._canClose = true
+    }, 2000)
+  }
+
+  protected override getToolbarButtons(): ToolButton[] {
+    const buttons = super.getToolbarButtons()
+
+    const updateButtonTitle = (cssClass: string, title: string, hint?: string): void => {
+      const button = tryFirst(buttons, x => x.cssClass === cssClass)
+      if (!button) return
+      button.title = title
+      if (hint !== undefined) button.hint = hint
+    }
+
+    updateButtonTitle('save-and-close-button', 'Save / Exit')
+    updateButtonTitle('apply-changes-button', 'Save', 'Save')
+
+    return buttons
+  }
+
+  protected override onSaveSuccess(response: SaveResponse): void {
+    super.onSaveSuccess(response)
+    this.initialEntity = this.getSaveEntity() as TItem
+    this.element[0].dispatchEvent(new Event('onDataChange'))
+  }
+
+  protected override onDialogClose(result?: string): void {
+    if (this.hasUnsavedChanges()) {
+      confirmDialog(this.confirmMessage, () => this.save(), {
+        title: this.confirmTitle,
+      })
+    }
+
+    if (!this.customEvent) this.setCustomEvent({})
+    this.element[0].dispatchEvent(this.customEvent!)
+    this.restoreActiveModal()
+    super.onDialogClose(result)
+  }
+
+  protected clearUnsavedChanges(): void {
+    this.initialEntity = this.getSaveEntity() as TItem
+  }
+
+  public hasUnsavedChanges(): boolean {
+    const currentEntity = this.getSaveEntity()
+    return !this.areEntitiesEqual(currentEntity, this.initialEntity)
+  }
+
+  private areEntitiesEqual(currentEntity: unknown, initialEntity: unknown): boolean {
+    if (!currentEntity || !initialEntity) return false
+    const current = currentEntity as Record<string, unknown>
+    const initial = initialEntity as Record<string, unknown>
+
+    return Object.keys(current).every(key => {
+      const currentValue = current[key]
+      const initialValue = initial[key]
+
+      const bothNaN =
+        typeof currentValue === 'number' &&
+        typeof initialValue === 'number' &&
+        Number.isNaN(currentValue) &&
+        Number.isNaN(initialValue)
+
+      const bothDates =
+        currentValue instanceof Date &&
+        initialValue instanceof Date &&
+        currentValue.getTime() === initialValue.getTime()
+
+      const bothNullish = currentValue == null && initialValue == null
+
+      const bothObjects =
+        typeof currentValue === 'object' &&
+        typeof initialValue === 'object' &&
+        currentValue !== null &&
+        initialValue !== null &&
+        JSON.stringify(currentValue) === JSON.stringify(initialValue)
+
+      return currentValue === initialValue || bothNaN || bothDates || bothNullish || bothObjects
+    })
+  }
+
+  private handleBeforeUnload(event: BeforeUnloadEvent): void {
+    if (this.hasUnsavedChanges()) {
+      event.preventDefault()
+      // Setting returnValue is the legacy mechanism for the browser to show a
+      // confirmation prompt. Modern browsers ignore the message but still
+      // honor preventDefault.
+      event.returnValue = ''
+    }
+  }
+
+  private restoreActiveModal(): void {
+    const modal = this.domNode.closest('.modal')
+    const currentLevel = parseInt(Fluent(modal as HTMLElement).data('qrouterorder') ?? '0', 10)
+    setActiveModal(currentLevel)
+  }
+
+  private initCloseButtonHandler(): void {
+    // Replace Serenity's built-in close button with one that gates on
+    // _canClose + hasUnsavedChanges. Deferred so we run after Serenity
+    // mounts the modal header.
+    setTimeout(() => {
+      let closeButton = this.element.parent().findFirst('.btn-close')
+      if (!closeButton[0]) closeButton = this.element.parent().findFirst('.panel-titlebar-close')
+
+      closeButton.style(css => {
+        css.display = 'none'
+      })
+
+      const btn = document.createElement('button')
+      btn.setAttribute('type', 'button')
+      btn.setAttribute('aria-label', 'Close')
+      btn.classList.add('btn-close-x')
+      btn.addEventListener('click', e => this.onCloseButtonClick(e))
+
+      let header = this.element.parent().findFirst('.modal-header')
+      if (!header[0]) {
+        header = this.element.parent().findFirst('.panel-titlebar')
+        btn.classList.add('ms-auto')
+      }
+      Fluent(btn).appendTo(header)
+    }, 0)
+  }
+
+  private waitForCanClose(): Promise<void> {
+    // Replaces the source's `setInterval(100ms)` polling. Resolves
+    // immediately if _canClose is already true; otherwise polls quietly.
+    return new Promise(resolve => {
+      if (this._canClose) {
+        resolve()
+        return
+      }
+      const id = setInterval(() => {
+        if (this._canClose) {
+          clearInterval(id)
+          resolve()
+        }
+      }, 100)
+    })
+  }
+
+  private async onCloseButtonClick(e: MouseEvent): Promise<void> {
+    e.preventDefault()
+    await this.waitForCanClose()
+
+    if (this.hasUnsavedChanges()) {
+      setInactiveModal(this.domNode, true)
+      confirmDialog(this.confirmMessage, () => this.save(), {
+        title: this.confirmTitle,
+        onNo: () => {
+          this.initialEntity = this.getSaveEntity() as TItem
+          this.dialogClose('save-with-leave-changes')
+        },
+      })
+      this.restoreActiveModal()
+    } else {
+      this.dialogClose('save-and-close')
+    }
+  }
+}

--- a/src/dialogs/idevsEntityDialog.ts
+++ b/src/dialogs/idevsEntityDialog.ts
@@ -43,6 +43,16 @@ export class IdevsEntityDialog<TItem, P = unknown> extends EntityDialog<TItem, P
   private _canClose = true
   private _isCloned = false
   private _beforeUnloadHandler?: (event: BeforeUnloadEvent) => void
+  private _initialSnapshotTimer?: ReturnType<typeof setTimeout>
+  private _canClosePollId?: ReturnType<typeof setInterval>
+  private _isDestroyed = false
+  /**
+   * Tracks whether the user has already responded to the unsaved-changes
+   * confirm prompt for the current close attempt. Without this, calling
+   * super.onDialogClose() while the prompt is still pending would close
+   * the dialog out from under the user.
+   */
+  private _userConfirmedClose = false
 
   private _confirmMessage = 'You have unsaved changes. Do you want to save before closing?'
   get confirmMessage(): string {
@@ -101,9 +111,18 @@ export class IdevsEntityDialog<TItem, P = unknown> extends EntityDialog<TItem, P
   }
 
   override destroy(): void {
+    this._isDestroyed = true
     if (this._beforeUnloadHandler) {
       window.removeEventListener('beforeunload', this._beforeUnloadHandler)
       this._beforeUnloadHandler = undefined
+    }
+    if (this._initialSnapshotTimer !== undefined) {
+      clearTimeout(this._initialSnapshotTimer)
+      this._initialSnapshotTimer = undefined
+    }
+    if (this._canClosePollId !== undefined) {
+      clearInterval(this._canClosePollId)
+      this._canClosePollId = undefined
     }
     super.destroy()
   }
@@ -140,11 +159,18 @@ export class IdevsEntityDialog<TItem, P = unknown> extends EntityDialog<TItem, P
   protected override updateInterface(): void {
     super.updateInterface()
 
-    // Delay closing until the form has finished its async loading. The
-    // PowerACC source used a hard 2-second timeout — fragile but
-    // load timings vary, so we preserve it as a documented constraint.
+    // Delay the snapshot until the form has finished its async loading.
+    // The PowerACC source used a hard 2-second timeout — fragile but load
+    // timings vary, so we preserve it as a documented constraint.
+    // Timer handle stored so destroy() can cancel it (otherwise the
+    // callback would run against a torn-down dialog and throw).
     this._canClose = false
-    setTimeout(() => {
+    if (this._initialSnapshotTimer !== undefined) {
+      clearTimeout(this._initialSnapshotTimer)
+    }
+    this._initialSnapshotTimer = setTimeout(() => {
+      this._initialSnapshotTimer = undefined
+      if (this._isDestroyed) return
       this.initialEntity = this.getSaveEntity() as TItem
       this._canClose = true
     }, 2000)
@@ -178,15 +204,46 @@ export class IdevsEntityDialog<TItem, P = unknown> extends EntityDialog<TItem, P
   }
 
   protected override onDialogClose(result?: string): void {
-    if (this.hasUnsavedChanges()) {
-      confirmDialog(this.confirmMessage, () => this.save(), {
-        title: this.confirmTitle,
-      })
+    // If the user hasn't yet responded to a confirm prompt AND there are
+    // unsaved changes, show the prompt and BLOCK the close. The dialog
+    // remains open until the user resolves the prompt (which then routes
+    // through save() or dialogClose with the confirmed flag set).
+    //
+    // Without this gate, the source's behavior was: confirmDialog fires
+    // async, but dispatch + super.onDialogClose runs synchronously — the
+    // dialog closes out from under the user. The Esc/backdrop paths still
+    // bypassed the gated close-button handler.
+    if (!this._userConfirmedClose && this.hasUnsavedChanges()) {
+      confirmDialog(
+        this.confirmMessage,
+        () => {
+          // User chose "yes, save" — save runs, onSaveSuccess clears the
+          // initialEntity snapshot so the next close attempt has nothing
+          // to confirm against.
+          this._userConfirmedClose = true
+          this.save()
+        },
+        {
+          title: this.confirmTitle,
+          onNo: () => {
+            // User chose "no, discard" — clear the snapshot so the close
+            // proceeds without re-prompting, then trigger close.
+            this._userConfirmedClose = true
+            this.initialEntity = this.getSaveEntity() as TItem
+            this.dialogClose(result ?? 'discarded-unsaved-changes')
+          },
+        },
+      )
+      // Block the close — the prompt's button handler will re-trigger
+      // dialogClose with _userConfirmedClose = true.
+      return
     }
 
+    // No unsaved changes, or the user already confirmed — proceed.
     if (!this.customEvent) this.setCustomEvent({})
     this.element[0].dispatchEvent(this.customEvent!)
     this.restoreActiveModal()
+    this._userConfirmedClose = false // reset for next open
     super.onDialogClose(result)
   }
 
@@ -290,14 +347,25 @@ export class IdevsEntityDialog<TItem, P = unknown> extends EntityDialog<TItem, P
   private waitForCanClose(): Promise<void> {
     // Replaces the source's `setInterval(100ms)` polling. Resolves
     // immediately if _canClose is already true; otherwise polls quietly.
+    // Interval handle stored on the instance so destroy() can clear it
+    // (otherwise a never-flipping _canClose would leak the interval forever).
     return new Promise(resolve => {
       if (this._canClose) {
         resolve()
         return
       }
-      const id = setInterval(() => {
+      // Clear any prior polling interval — only one waiter at a time.
+      if (this._canClosePollId !== undefined) clearInterval(this._canClosePollId)
+      this._canClosePollId = setInterval(() => {
+        if (this._isDestroyed) {
+          if (this._canClosePollId !== undefined) clearInterval(this._canClosePollId)
+          this._canClosePollId = undefined
+          resolve()
+          return
+        }
         if (this._canClose) {
-          clearInterval(id)
+          if (this._canClosePollId !== undefined) clearInterval(this._canClosePollId)
+          this._canClosePollId = undefined
           resolve()
         }
       }, 100)

--- a/src/dialogs/idevsEntityDialog.ts
+++ b/src/dialogs/idevsEntityDialog.ts
@@ -54,11 +54,18 @@ export class IdevsEntityDialog<TItem, P = unknown> extends EntityDialog<TItem, P
   private _isDestroyed = false
   /**
    * Tracks whether the user has already responded to the unsaved-changes
-   * confirm prompt for the current close attempt. Without this, calling
-   * super.onDialogClose() while the prompt is still pending would close
-   * the dialog out from under the user.
+   * confirm prompt for the current close attempt. The hide.bs.modal
+   * before-close listener (setupBeforeCloseGate) checks this flag and
+   * preventDefault's the close when it's false AND the form is dirty.
    */
   private _userConfirmedClose = false
+  /**
+   * The Bootstrap modal element (the `.modal` wrapper around domNode)
+   * that we attach the hide.bs.modal listener to. Captured at open time
+   * for clean detach in destroy().
+   */
+  private _modalEl?: HTMLElement
+  private _beforeCloseHandler?: (e: Event) => void
 
   private _confirmMessage = 'You have unsaved changes. Do you want to save before closing?'
   get confirmMessage(): string {
@@ -134,6 +141,7 @@ export class IdevsEntityDialog<TItem, P = unknown> extends EntityDialog<TItem, P
       clearInterval(this._canClosePollId)
       this._canClosePollId = undefined
     }
+    this.teardownBeforeCloseGate()
     super.destroy()
   }
 
@@ -162,9 +170,108 @@ export class IdevsEntityDialog<TItem, P = unknown> extends EntityDialog<TItem, P
     this.cloneButton?.toggle(this.isEditMode())
 
     this.initCloseButtonHandler()
+    this.setupBeforeCloseGate()
     setInactiveModal(this.domNode)
 
     super.onDialogOpen()
+  }
+
+  /**
+   * Register the Bootstrap `hide.bs.modal` before-close listener that
+   * gates Esc / backdrop / programmatic close paths on the dirty-check
+   * prompt.
+   *
+   * Why a before-close listener rather than the inherited
+   * `onDialogClose` override: Serenity's `onDialogClose` is invoked from
+   * the AFTER-close hook (the modal is already hiding when it fires).
+   * Returning early from `onDialogClose` does NOT keep the modal
+   * visible. The confirm prompt would appear over a hidden modal and
+   * the user could end up with an orphaned dialog state. Bootstrap's
+   * `hide.bs.modal` fires BEFORE the hide animation and respects
+   * `preventDefault()` — that's what we need to actually gate the
+   * close.
+   *
+   * Flow:
+   *   1. User presses Esc / clicks backdrop / calls `dialogClose()`.
+   *   2. Bootstrap dispatches `hide.bs.modal`.
+   *   3. Our handler fires: if not yet confirmed AND dirty,
+   *      `e.preventDefault()` (modal stays open) and show the confirm
+   *      prompt.
+   *   4. Prompt's onYes-save-success or onNo-discard callback sets
+   *      `_userConfirmedClose = true` then calls `dialogClose()`.
+   *   5. Bootstrap re-dispatches `hide.bs.modal`; our handler sees the
+   *      flag and lets the close proceed.
+   *   6. After Bootstrap finishes hiding, `onDialogClose` runs and
+   *      dispatches `customEvent` + cleanup. The flag is reset there
+   *      for the next open.
+   */
+  private setupBeforeCloseGate(): void {
+    // Deferred — Serenity's modal wrapper may not be in the DOM yet at
+    // the moment onDialogOpen fires. setTimeout(0) lets the mount settle.
+    setTimeout(() => {
+      if (this._isDestroyed) return
+      const modal = this.domNode.closest<HTMLElement>('.modal')
+      if (!modal) return
+
+      // Replace any prior wiring (defensive — onDialogOpen runs on every
+      // open of a reused dialog instance).
+      this.teardownBeforeCloseGate()
+
+      const handler = (e: Event) => {
+        if (this._userConfirmedClose) return
+        if (!this.hasUnsavedChanges()) return
+        e.preventDefault()
+        this.showDirtyCloseConfirm()
+      }
+      modal.addEventListener('hide.bs.modal', handler)
+      this._modalEl = modal
+      this._beforeCloseHandler = handler
+    }, 0)
+  }
+
+  private teardownBeforeCloseGate(): void {
+    if (this._modalEl && this._beforeCloseHandler) {
+      this._modalEl.removeEventListener('hide.bs.modal', this._beforeCloseHandler)
+    }
+    this._modalEl = undefined
+    this._beforeCloseHandler = undefined
+  }
+
+  /**
+   * Show the confirm prompt for an unsaved-changes close attempt. Used
+   * by both the before-close gate (setupBeforeCloseGate) and the
+   * custom close button (onCloseButtonClick). Both paths route through
+   * this single implementation so the user only ever sees ONE prompt
+   * spelling and `_userConfirmedClose` is set in one place per outcome.
+   */
+  private showDirtyCloseConfirm(result?: string): void {
+    confirmDialog(
+      this.confirmMessage,
+      () => {
+        // Yes, save. Validate first so the user gets explicit feedback if
+        // validation blocks the save — Serenity's inline errors fire too
+        // but are easy to miss while focus is on the prompt.
+        if (!this.validateBeforeSave()) {
+          notifyError('Save failed — please review the form for validation errors.')
+          return
+        }
+        this.save(() => {
+          this._userConfirmedClose = true
+          this.dialogClose(result ?? 'save-and-close')
+        })
+      },
+      {
+        title: this.confirmTitle,
+        onNo: () => {
+          // Discard — clear the snapshot so subsequent dirty checks pass,
+          // then trigger close. The before-close handler will see the
+          // confirmed flag and let it through.
+          this._userConfirmedClose = true
+          this.initialEntity = this.getSaveEntity() as TItem
+          this.dialogClose(result ?? 'discarded-unsaved-changes')
+        },
+      },
+    )
   }
 
   protected setCustomEvent(detail: unknown): void {
@@ -229,64 +336,26 @@ export class IdevsEntityDialog<TItem, P = unknown> extends EntityDialog<TItem, P
   }
 
   protected override onDialogClose(result?: string): void {
-    // If the user hasn't yet responded to a confirm prompt AND there are
-    // unsaved changes, show the prompt and BLOCK the close. The dialog
-    // remains open until the user resolves the prompt (which then routes
-    // through save() or dialogClose with the confirmed flag set).
-    //
-    // Without this gate, the source's behavior was: confirmDialog fires
-    // async, but dispatch + super.onDialogClose runs synchronously — the
-    // dialog closes out from under the user. The Esc/backdrop paths still
-    // bypassed the gated close-button handler.
-    if (!this._userConfirmedClose && this.hasUnsavedChanges()) {
-      confirmDialog(
-        this.confirmMessage,
-        () => {
-          // User chose "yes, save". Run validation first — if the form is
-          // invalid, surface a notifyError so the user knows why the close
-          // didn't proceed (Serenity's inline validation also fires, but
-          // it's easy to miss when focus is on the prompt button).
-          if (!this.validateBeforeSave()) {
-            notifyError('Save failed — please review the form for validation errors.')
-            return
-          }
-          // ONLY on save success do we set the confirmed flag and close.
-          // If save fails (service error post-validation) the callback
-          // never fires — the dialog stays open with the unsaved-changes
-          // state intact, so the next close attempt re-prompts.
-          this.save(() => {
-            this._userConfirmedClose = true
-            this.dialogClose(result ?? 'save-and-close')
-          })
-        },
-        {
-          title: this.confirmTitle,
-          onNo: () => {
-            // User chose "no, discard" — clear the snapshot so the close
-            // proceeds without re-prompting, then trigger close.
-            this._userConfirmedClose = true
-            this.initialEntity = this.getSaveEntity() as TItem
-            this.dialogClose(result ?? 'discarded-unsaved-changes')
-          },
-        },
-      )
-      // Block the close — the prompt's button handler will re-trigger
-      // dialogClose with _userConfirmedClose = true.
-      return
-    }
-
-    // No unsaved changes, or the user already confirmed — proceed.
+    // onDialogClose runs from the AFTER-close hook — by the time we get
+    // here the modal is already hiding. The dirty-close GATE lives in
+    // setupBeforeCloseGate (a hide.bs.modal preventDefault listener); we
+    // only reach onDialogClose when the close is actually allowed to
+    // proceed (either no unsaved changes OR user already confirmed).
+    // This method's responsibility: dispatch customEvent, restore modal
+    // stack layering, reset the confirmed flag for the next open, and
+    // tear down the before-close listener.
     if (!this.customEvent) this.setCustomEvent({})
     const evt = this.customEvent!
     this.element[0].dispatchEvent(evt)
     // Clear the customEvent after dispatch — without this, a reused
-    // dialog instance can replay stale `detail` from a prior close (e.g.,
-    // a subclass called setCustomEvent during a save flow, then the user
-    // opens + closes again without triggering a fresh setCustomEvent).
-    // Reset forces the next close to either set a fresh payload or fall
-    // back to an empty {}.
+    // dialog instance can replay stale `detail` from a prior close
+    // (e.g., a subclass called setCustomEvent during a save flow, then
+    // the user opens + closes again without triggering a fresh
+    // setCustomEvent). Reset forces the next close to either set a
+    // fresh payload or fall back to an empty {}.
     this.customEvent = undefined
     this.restoreActiveModal()
+    this.teardownBeforeCloseGate()
     this._userConfirmedClose = false // reset for next open
     super.onDialogClose(result)
   }
@@ -438,52 +507,13 @@ export class IdevsEntityDialog<TItem, P = unknown> extends EntityDialog<TItem, P
   private async onCloseButtonClick(e: MouseEvent): Promise<void> {
     e.preventDefault()
     await this.waitForCanClose()
-    // waitForCanClose() resolves on destroy too (so the Promise doesn't
-    // leak the interval). Re-check the destroyed flag here — without this
-    // guard, hasUnsavedChanges / dialogClose would run against a torn-down
-    // dialog and throw on detached DOM.
     if (this._isDestroyed) return
-
-    if (this.hasUnsavedChanges()) {
-      setInactiveModal(this.domNode, true)
-      confirmDialog(
-        this.confirmMessage,
-        () => {
-          // Validate FIRST; surface a notifyError if invalid so the user
-          // sees concrete feedback at the close-attempt level (Serenity's
-          // inline errors also fire but can be missed when focus is on
-          // the prompt). On validation pass, save; on save success
-          // (callback fires), set the confirmed flag + close.
-          if (!this.validateBeforeSave()) {
-            notifyError('Save failed — please review the form for validation errors.')
-            // Restore modal layering since the close was cancelled.
-            this.restoreActiveModal()
-            return
-          }
-          this.save(() => {
-            this._userConfirmedClose = true
-            this.dialogClose('save-and-close')
-          })
-        },
-        {
-          title: this.confirmTitle,
-          onNo: () => {
-            this._userConfirmedClose = true
-            this.initialEntity = this.getSaveEntity() as TItem
-            this.dialogClose('save-with-leave-changes')
-          },
-        },
-      )
-      // NOTE: restoreActiveModal moved into the prompt callbacks above
-      // (review round 10 fix). The previous unconditional restore here
-      // ran synchronously AFTER queueing the async confirmDialog,
-      // undoing the inactive-modal layering before the user saw the
-      // prompt. Now restoration happens only when the prompt resolves
-      // (yes-validate-fail path; the yes-save-success path goes through
-      // dialogClose, which triggers a fresh onDialogClose → restore).
-    } else {
-      this.dialogClose('save-and-close')
-    }
+    // Route through dialogClose — the before-close gate
+    // (setupBeforeCloseGate) sees the resulting hide.bs.modal and runs
+    // the dirty-check + confirm prompt centrally. Previously this method
+    // duplicated the prompt logic; consolidated so all close paths
+    // (Esc, backdrop, programmatic, custom X button) hit one prompt.
+    this.dialogClose('save-and-close')
   }
 
   /**

--- a/src/dialogs/idevsEntityDialog.ts
+++ b/src/dialogs/idevsEntityDialog.ts
@@ -232,12 +232,13 @@ export class IdevsEntityDialog<TItem, P = unknown> extends EntityDialog<TItem, P
       confirmDialog(
         this.confirmMessage,
         () => {
-          // User chose "yes, save". Save runs; on success we close the
-          // dialog. Without the success callback driving dialogClose,
-          // the user's action ("save and close") would degrade into a
-          // bare save while the dialog stays open.
-          this._userConfirmedClose = true
+          // User chose "yes, save". Save runs; ONLY on success do we
+          // set the confirmed flag and close the dialog. If save fails
+          // (validation, service error) the success callback is never
+          // invoked — the dialog stays open with the unsaved-changes
+          // state intact, so the next close attempt re-prompts.
           this.save(() => {
+            this._userConfirmedClose = true
             this.dialogClose(result ?? 'save-and-close')
           })
         },
@@ -414,10 +415,12 @@ export class IdevsEntityDialog<TItem, P = unknown> extends EntityDialog<TItem, P
       confirmDialog(
         this.confirmMessage,
         () => {
-          // Save AND close — pass dialogClose to save() so this is a real
-          // save-and-close, not a bare save that leaves the dialog open.
-          this._userConfirmedClose = true
+          // Save AND close — set the confirmed flag and close ONLY after
+          // save succeeds. A failed save (validation, service error)
+          // leaves _userConfirmedClose false, so the next close attempt
+          // re-prompts instead of silently discarding the dirty edits.
           this.save(() => {
+            this._userConfirmedClose = true
             this.dialogClose('save-and-close')
           })
         },

--- a/src/dialogs/idevsEntityDialog.ts
+++ b/src/dialogs/idevsEntityDialog.ts
@@ -232,11 +232,14 @@ export class IdevsEntityDialog<TItem, P = unknown> extends EntityDialog<TItem, P
       confirmDialog(
         this.confirmMessage,
         () => {
-          // User chose "yes, save" — save runs, onSaveSuccess clears the
-          // initialEntity snapshot so the next close attempt has nothing
-          // to confirm against.
+          // User chose "yes, save". Save runs; on success we close the
+          // dialog. Without the success callback driving dialogClose,
+          // the user's action ("save and close") would degrade into a
+          // bare save while the dialog stays open.
           this._userConfirmedClose = true
-          this.save()
+          this.save(() => {
+            this.dialogClose(result ?? 'save-and-close')
+          })
         },
         {
           title: this.confirmTitle,
@@ -399,13 +402,25 @@ export class IdevsEntityDialog<TItem, P = unknown> extends EntityDialog<TItem, P
 
     if (this.hasUnsavedChanges()) {
       setInactiveModal(this.domNode, true)
-      confirmDialog(this.confirmMessage, () => this.save(), {
-        title: this.confirmTitle,
-        onNo: () => {
-          this.initialEntity = this.getSaveEntity() as TItem
-          this.dialogClose('save-with-leave-changes')
+      confirmDialog(
+        this.confirmMessage,
+        () => {
+          // Save AND close — pass dialogClose to save() so this is a real
+          // save-and-close, not a bare save that leaves the dialog open.
+          this._userConfirmedClose = true
+          this.save(() => {
+            this.dialogClose('save-and-close')
+          })
         },
-      })
+        {
+          title: this.confirmTitle,
+          onNo: () => {
+            this._userConfirmedClose = true
+            this.initialEntity = this.getSaveEntity() as TItem
+            this.dialogClose('save-with-leave-changes')
+          },
+        },
+      )
       this.restoreActiveModal()
     } else {
       this.dialogClose('save-and-close')

--- a/src/dialogs/idevsEntityDialog.ts
+++ b/src/dialogs/idevsEntityDialog.ts
@@ -147,8 +147,13 @@ export class IdevsEntityDialog<TItem, P = unknown> extends EntityDialog<TItem, P
   }
 
   protected override onDialogOpen(): void {
-    this.localizerButton?.hide()
-    this.undeleteButton?.hide()
+    // Honor the public alwaysDisableLocalization / alwaysDisableUndelete
+    // flags — defaults stay `true` to preserve the source's hide-by-default
+    // behavior, but consumers who flip either to false get the standard
+    // Serenity button back. Previously these flags were settable but
+    // ignored, presenting a misleading public API.
+    if (this._alwaysDisableLocalization) this.localizerButton?.hide()
+    if (this._alwaysDisableUndelete) this.undeleteButton?.hide()
     this.cloneButton?.toggle(this.isEditMode())
 
     this.initCloseButtonHandler()
@@ -409,6 +414,11 @@ export class IdevsEntityDialog<TItem, P = unknown> extends EntityDialog<TItem, P
   private async onCloseButtonClick(e: MouseEvent): Promise<void> {
     e.preventDefault()
     await this.waitForCanClose()
+    // waitForCanClose() resolves on destroy too (so the Promise doesn't
+    // leak the interval). Re-check the destroyed flag here — without this
+    // guard, hasUnsavedChanges / dialogClose would run against a torn-down
+    // dialog and throw on detached DOM.
+    if (this._isDestroyed) return
 
     if (this.hasUnsavedChanges()) {
       setInactiveModal(this.domNode, true)

--- a/src/dialogs/idevsInlineDialog.ts
+++ b/src/dialogs/idevsInlineDialog.ts
@@ -66,6 +66,10 @@ export class IdevsInlineDialog<TEntity = Record<string, unknown>> extends Widget
   IdevsInlineDialogOptions<TEntity>
 > {
   private dialog!: DialogInternals<TEntity>
+  /** Tracked deferred-init timers (emptyFields + customButtons) so destroy
+   *  can cancel them before they fire against a torn-down dialog. */
+  private pendingInitTimers: Array<ReturnType<typeof setTimeout>> = []
+  private isDestroyed = false
 
   static override createDefaultElement(): HTMLElement {
     return Fluent('div')
@@ -79,6 +83,12 @@ export class IdevsInlineDialog<TEntity = Record<string, unknown>> extends Widget
   }
 
   override destroy(): void {
+    this.isDestroyed = true
+    // Cancel any pending init timers — emptyFields/customButtons mutate the
+    // embedded dialog's DOM, which would throw or mis-render against a
+    // destroyed dialog instance.
+    for (const id of this.pendingInitTimers) clearTimeout(id)
+    this.pendingInitTimers = []
     // Tear down the embedded dialog before our own destroy chain — its
     // form change listeners hold references back through `this`, so
     // disposing it first ensures no listener fires during teardown.
@@ -90,6 +100,17 @@ export class IdevsInlineDialog<TEntity = Record<string, unknown>> extends Widget
       }
     }
     super.destroy()
+  }
+
+  /** Schedule a deferred init step with destroy-safe cancellation. */
+  private scheduleInit(cb: () => void, delay: number): void {
+    if (this.isDestroyed) return
+    const id = setTimeout(() => {
+      this.pendingInitTimers = this.pendingInitTimers.filter(t => t !== id)
+      if (this.isDestroyed) return
+      cb()
+    }, delay)
+    this.pendingInitTimers.push(id)
   }
 
   public async callPageCallback<K extends keyof IdevsInlineDialogCallbacks<TEntity>>(
@@ -161,10 +182,10 @@ export class IdevsInlineDialog<TEntity = Record<string, unknown>> extends Widget
     void this.loadNew()
 
     if (this.options.emptyFields && this.options.emptyFields.length > 0) {
-      setTimeout(() => this.addEmptyFields(), 100)
+      this.scheduleInit(() => this.addEmptyFields(), 100)
     }
     if (this.options.customButtons && this.options.customButtons.length > 0) {
-      setTimeout(() => this.addCustomButtons(), 100)
+      this.scheduleInit(() => this.addCustomButtons(), 100)
     }
   }
 

--- a/src/dialogs/idevsInlineDialog.ts
+++ b/src/dialogs/idevsInlineDialog.ts
@@ -1,0 +1,273 @@
+import {
+  Decorators,
+  EntityDialog,
+  Fluent,
+  Widget,
+  type WidgetProps,
+} from '@serenity-is/corelib'
+
+/**
+ * Inline dialog wrapper — embeds another `EntityDialog` subclass into a
+ * non-modal container, optionally hiding the toolbar and adding custom
+ * buttons / empty field slots.
+ *
+ * Replaces PowerACC's `CsiInlineDialog`. Hardening vs source:
+ *   - `style: Partial<CSSStyleDeclaration> | string` → object only (the
+ *     string variant in the source allowed arbitrary CSS injection).
+ *   - `any` entity types → `TEntity` generic throughout.
+ *   - Narrowed `(this.dialog as any).validateForm()` / `form[fieldName]`
+ *     access via structural types.
+ */
+
+export type IdevsCustomButton = {
+  id: string
+  text: string
+  columnCssClass?: string
+  cssClass?: string
+  /** Object form only — the source allowed a raw CSS string (XSS-adjacent). */
+  style?: Partial<CSSStyleDeclaration>
+  click?: (e: Event) => void
+  afterField?: string
+}
+
+export type IdevsEmptyField = {
+  columnCssClass?: string
+  cssClass?: string
+  style?: Partial<CSSStyleDeclaration>
+  afterField?: string
+}
+
+export type IdevsInlineDialogCallbacks<TEntity> = {
+  onSave?: (entity: TEntity, response: unknown) => void | Promise<void>
+  onLoad?: (entity: TEntity | unknown) => void | Promise<void>
+  onValidate?: (entity: TEntity) => boolean | Promise<boolean>
+  onFormChange?: (entity: TEntity, fieldName?: string) => void | Promise<void>
+  onCustomAction?: (actionName: string, data?: unknown) => void | Promise<void>
+}
+
+export type IdevsInlineDialogOptions<TEntity> = {
+  dialogType: new (options?: unknown) => EntityDialog<TEntity, unknown>
+  dialogOptions?: unknown
+  hideToolbar?: boolean
+  customButtons?: (IdevsCustomButton | IdevsCustomButton[])[]
+  emptyFields?: IdevsEmptyField[]
+  callbacks?: IdevsInlineDialogCallbacks<TEntity>
+}
+
+type DialogInternals<TEntity> = EntityDialog<TEntity, unknown> & {
+  validateForm(): boolean
+  save(callback: (response: unknown) => void): void
+  form: Record<string, { element: Fluent; value: unknown }>
+  arrange?: () => void
+}
+
+@Decorators.registerClass('Idevs.CoreLib.IdevsInlineDialog')
+export class IdevsInlineDialog<TEntity = Record<string, unknown>> extends Widget<
+  IdevsInlineDialogOptions<TEntity>
+> {
+  private dialog!: DialogInternals<TEntity>
+
+  static override createDefaultElement(): HTMLElement {
+    return Fluent('div')
+      .class(['idevs-inline-dialog', 's-IdevsInlineDialog', 'w-100', 'h-100', 'p-3'])
+      .getNode()
+  }
+
+  constructor(props: WidgetProps<IdevsInlineDialogOptions<TEntity>>) {
+    super(props)
+    this.initializeDialog()
+  }
+
+  public async callPageCallback<K extends keyof IdevsInlineDialogCallbacks<TEntity>>(
+    callbackName: K,
+    ...args: Parameters<NonNullable<IdevsInlineDialogCallbacks<TEntity>[K]>>
+  ): Promise<ReturnType<NonNullable<IdevsInlineDialogCallbacks<TEntity>[K]>> | undefined> {
+    const callback = this.options.callbacks?.[callbackName] as
+      | ((...a: unknown[]) => unknown)
+      | undefined
+    if (!callback) return undefined
+    return (await callback(...args)) as ReturnType<
+      NonNullable<IdevsInlineDialogCallbacks<TEntity>[K]>
+    >
+  }
+
+  public clearDialogForm(): void {
+    this.dialog.dialogClose()
+    this.loadNew()
+  }
+
+  public async saveDialogForm(): Promise<unknown> {
+    // Refactored from `new Promise(async (resolve, reject) => ...)` which
+    // ESLint flags as no-async-promise-executor — async errors inside the
+    // executor are not awaited by the promise. Now using direct
+    // async/await + a leaf Promise for the save() callback.
+    const customValidation = await this.callPageCallback('onValidate', this.getEntity())
+    if (customValidation === false) {
+      throw new Error('Custom validation failed')
+    }
+    if (!this.dialog.validateForm()) {
+      throw new Error('Form validation failed')
+    }
+    return new Promise<unknown>((resolve, reject) => {
+      this.dialog.save(response => {
+        if (!response) {
+          reject(new Error('Save operation failed'))
+          return
+        }
+        // Best-effort onSave callback; failures here don't block resolution.
+        void this.callPageCallback('onSave', this.getEntity(), response).then(() => {
+          resolve(response)
+        })
+      })
+    })
+  }
+
+  private initializeDialog(): void {
+    const DialogType = this.options.dialogType
+    this.dialog = new DialogType({
+      element: document.createElement('div'),
+      ...(this.options.dialogOptions as Record<string, unknown>),
+    }) as DialogInternals<TEntity>
+
+    const dialogElement = this.dialog.element.getNode()
+    this.removeModalBehavior(dialogElement)
+
+    if (this.options.hideToolbar) {
+      const toolbar = dialogElement.querySelector<HTMLElement>('.s-Toolbar')
+      if (toolbar) toolbar.style.display = 'none'
+    }
+
+    this.element.append(dialogElement)
+    this.overrideModalMethods()
+    this.setupFormChangeListener()
+
+    void this.loadNew()
+
+    if (this.options.emptyFields && this.options.emptyFields.length > 0) {
+      setTimeout(() => this.addEmptyFields(), 100)
+    }
+    if (this.options.customButtons && this.options.customButtons.length > 0) {
+      setTimeout(() => this.addCustomButtons(), 100)
+    }
+  }
+
+  private setupFormChangeListener(): void {
+    const form = this.dialog.element.findFirst('.s-Form')
+    if (!form[0]) return
+
+    form.findAll('.field[data-itemname]').forEach(input => {
+      const fieldName = input.getAttribute('data-itemname')
+      if (!fieldName) return
+      const formInput = this.dialog.form[fieldName]
+      if (!formInput) return
+      formInput.element.on('change', async () => {
+        const entity = this.getEntity()
+        await this.callPageCallback('onFormChange', entity, fieldName)
+      })
+    })
+  }
+
+  private addEmptyFields(): void {
+    if (!this.options.emptyFields) return
+    this.options.emptyFields.forEach(field => {
+      const newField = Fluent('div').class(['field', 'col-12', field.columnCssClass ?? ''])
+      if (field.style) Object.assign(newField.getNode().style, field.style)
+
+      const fields = this.dialog.element.findAll('.s-Form .field')
+      const lastField = fields[fields.length - 1]
+      const afterField = field.afterField
+        ? fields.find(f => f.classList.contains(field.afterField!))
+        : null
+      const target = afterField ?? lastField
+      target?.insertAdjacentElement('afterend', newField.getNode())
+    })
+  }
+
+  private addCustomButtons(): void {
+    if (!this.options.customButtons) return
+    this.options.customButtons.forEach(buttonOrArray => {
+      const buttons = Array.isArray(buttonOrArray) ? buttonOrArray : [buttonOrArray]
+      const newField = Fluent('div').class([
+        'field',
+        'col-12',
+        buttons[0].columnCssClass ?? '',
+      ])
+
+      buttons.forEach(button => {
+        const buttonElement = Fluent('button')
+          .class(['btn', button.cssClass ?? ''])
+          .text(button.text)
+          .on('click', button.click ?? (() => {}))
+        // Object form only — string variant from source removed (XSS-adjacent).
+        if (button.style) Object.assign(buttonElement.getNode().style, button.style)
+        buttonElement.appendTo(newField)
+      })
+
+      const fields = this.dialog.element.findAll('.s-Form .field')
+      const lastField = fields[fields.length - 1]
+      const afterField = buttons[0].afterField
+        ? fields.find(f => f.classList.contains(buttons[0].afterField!))
+        : null
+      const target = afterField ?? lastField
+      target?.insertAdjacentElement('afterend', newField.getNode())
+    })
+  }
+
+  private removeModalBehavior(dialogElement: HTMLElement): void {
+    dialogElement.classList.remove('modal', 'fade')
+    dialogElement.removeAttribute('tabindex')
+    dialogElement.removeAttribute('aria-labelledby')
+    dialogElement.removeAttribute('aria-hidden')
+    dialogElement.removeAttribute('role')
+  }
+
+  private overrideModalMethods(): void {
+    // Suppress modal lifecycle on the embedded dialog — we're rendering it
+    // inline, not as a popup. The dialog's own open/close behavior would
+    // try to mount/unmount the modal scaffolding we just stripped.
+    this.dialog.dialogOpen = () => {}
+    this.dialog.dialogClose = () => {}
+    if (this.dialog.arrange) this.dialog.arrange = () => {}
+  }
+
+  public async loadEntity(entity: TEntity): Promise<void> {
+    this.dialog.loadEntityAndOpenDialog(entity)
+    await this.callPageCallback('onLoad', entity)
+  }
+
+  public async loadById(id: string | number): Promise<void> {
+    this.dialog.loadByIdAndOpenDialog(id as never)
+    await this.callPageCallback('onLoad', this.getEntity())
+  }
+
+  public async loadNew(): Promise<void> {
+    this.dialog.loadNewAndOpenDialog()
+    await this.callPageCallback('onLoad', this.dialog.element as unknown as TEntity)
+  }
+
+  public async triggerCustomAction(actionName: string, data?: unknown): Promise<unknown> {
+    return this.callPageCallback('onCustomAction', actionName, data)
+  }
+
+  public getEntity(): TEntity {
+    if (this.dialog.entity && Object.keys(this.dialog.entity as Record<string, unknown>).length > 0) {
+      return this.dialog.entity
+    }
+    const form = this.dialog.element.findFirst('.s-Form')
+    if (!form[0]) return {} as TEntity
+
+    const entity = {} as Record<string, unknown>
+    form.findAll('.field[data-itemname]').forEach(input => {
+      const fieldName = input.getAttribute('data-itemname')
+      if (!fieldName) return
+      const formInput = this.dialog.form[fieldName]
+      if (!formInput) return
+      entity[fieldName] = formInput.value
+    })
+    return entity as TEntity
+  }
+
+  public validateForm(): boolean {
+    return this.dialog.validateForm()
+  }
+}

--- a/src/dialogs/idevsInlineDialog.ts
+++ b/src/dialogs/idevsInlineDialog.ts
@@ -233,6 +233,14 @@ export class IdevsInlineDialog<TEntity = Record<string, unknown>> extends Widget
 
       buttons.forEach(button => {
         const buttonElement = Fluent('button')
+          // Explicit type='button' — without this, the button inherits
+          // the embedded form's submit semantics and clicking it triggers
+          // form validation + submit AS WELL AS the custom click handler.
+          .attr('type', 'button')
+          // Honor IdevsCustomButton.id — the option type marks it as
+          // required but the source never propagated it to the element,
+          // breaking styling/lookup/testability.
+          .attr('id', button.id)
           .class(['btn', button.cssClass ?? ''])
           .text(button.text)
           .on('click', button.click ?? (() => {}))

--- a/src/dialogs/idevsInlineDialog.ts
+++ b/src/dialogs/idevsInlineDialog.ts
@@ -78,6 +78,20 @@ export class IdevsInlineDialog<TEntity = Record<string, unknown>> extends Widget
     this.initializeDialog()
   }
 
+  override destroy(): void {
+    // Tear down the embedded dialog before our own destroy chain — its
+    // form change listeners hold references back through `this`, so
+    // disposing it first ensures no listener fires during teardown.
+    if (this.dialog) {
+      try {
+        this.dialog.destroy()
+      } catch {
+        /* swallow — teardown errors are noise */
+      }
+    }
+    super.destroy()
+  }
+
   public async callPageCallback<K extends keyof IdevsInlineDialogCallbacks<TEntity>>(
     callbackName: K,
     ...args: Parameters<NonNullable<IdevsInlineDialogCallbacks<TEntity>[K]>>
@@ -114,10 +128,13 @@ export class IdevsInlineDialog<TEntity = Record<string, unknown>> extends Widget
           reject(new Error('Save operation failed'))
           return
         }
-        // Best-effort onSave callback; failures here don't block resolution.
-        void this.callPageCallback('onSave', this.getEntity(), response).then(() => {
-          resolve(response)
-        })
+        // Best-effort onSave callback; settles the outer Promise regardless
+        // of whether the callback resolves, rejects, or throws. Without the
+        // .catch leg, an onSave that throws would leave saveDialogForm
+        // pending forever AND emit an unhandledrejection.
+        this.callPageCallback('onSave', this.getEntity(), response)
+          .then(() => resolve(response))
+          .catch(() => resolve(response))
       })
     })
   }

--- a/src/dialogs/idevsInlineDialog.ts
+++ b/src/dialogs/idevsInlineDialog.ts
@@ -59,6 +59,14 @@ type DialogInternals<TEntity> = EntityDialog<TEntity, unknown> & {
   save(callback: (response: unknown) => void): void
   form: Record<string, { element: Fluent; value: unknown }>
   arrange?: () => void
+  /**
+   * Callback-bearing retrieve API on Serenity's EntityDialog. The
+   * "AndOpenDialog" variants kick off an async service call and don't
+   * expose completion — use these for cases where the caller needs to
+   * know when the load finished (e.g., to fire onLoad with a populated
+   * entity rather than firing it immediately against an empty one).
+   */
+  loadById(id: unknown, done?: () => void, fail?: () => void): void
 }
 
 @Decorators.registerClass('Idevs.CoreLib.IdevsInlineDialog')
@@ -293,15 +301,39 @@ export class IdevsInlineDialog<TEntity = Record<string, unknown>> extends Widget
     if (loadErr) throw loadErr
   }
 
-  public async loadById(id: string | number): Promise<void> {
-    let loadErr: unknown
-    try {
-      this.dialog.loadByIdAndOpenDialog(id as never)
-    } catch (e) {
-      loadErr = e
-    }
-    await this.callPageCallback('onLoad', this.getEntity())
-    if (loadErr) throw loadErr
+  public loadById(id: string | number): Promise<void> {
+    // Use the callback-bearing `loadById` (not `loadByIdAndOpenDialog`)
+    // and await the service response BEFORE firing onLoad. Previously
+    // we fired loadByIdAndOpenDialog synchronously and called
+    // callPageCallback('onLoad', getEntity()) on the next tick — the
+    // service call was still in flight, so onLoad observed an EMPTY
+    // entity and the returned promise resolved before the dialog
+    // actually had data. Consumers using onLoad to initialize dependent
+    // UI got stale/missing data.
+    //
+    // The "AndOpenDialog" suffix is irrelevant here — IdevsInlineDialog
+    // overrides `dialogOpen` to a no-op (inline rendering, not modal),
+    // so we don't need that path.
+    return new Promise<void>((resolve, reject) => {
+      try {
+        this.dialog.loadById(
+          id as unknown,
+          () => {
+            // Loaded — fire onLoad with the now-populated entity.
+            this.callPageCallback('onLoad', this.getEntity())
+              .then(() => resolve())
+              .catch(reject)
+          },
+          () => {
+            // Serenity surfaces its own error toast/inline message;
+            // reject the outer promise so awaiters can react.
+            reject(new Error(`IdevsInlineDialog.loadById failed for id: ${String(id)}`))
+          },
+        )
+      } catch (e) {
+        reject(e)
+      }
+    })
   }
 
   public async loadNew(): Promise<void> {
@@ -325,21 +357,28 @@ export class IdevsInlineDialog<TEntity = Record<string, unknown>> extends Widget
   }
 
   public getEntity(): TEntity {
-    if (this.dialog.entity && Object.keys(this.dialog.entity as Record<string, unknown>).length > 0) {
-      return this.dialog.entity
-    }
+    // Always read CURRENT form values first, then merge over the loaded
+    // entity so non-form fields (IDs, audit timestamps, etc.) are
+    // preserved while user edits propagate to consumer callbacks.
+    //
+    // The previous implementation returned `this.dialog.entity` directly
+    // when it was non-empty — that meant any consumer of onFormChange /
+    // onValidate / onSave / onCustomAction observed the ORIGINAL loaded
+    // values, not the user's current edits. Validation / save-side logic
+    // would run against stale data for existing records.
+    const loadedEntity = (this.dialog.entity as Record<string, unknown> | undefined) ?? {}
     const form = this.dialog.element.findFirst('.s-Form')
-    if (!form[0]) return {} as TEntity
+    if (!form[0]) return loadedEntity as TEntity
 
-    const entity = {} as Record<string, unknown>
+    const formEntity: Record<string, unknown> = { ...loadedEntity }
     form.findAll('.field[data-itemname]').forEach(input => {
       const fieldName = input.getAttribute('data-itemname')
       if (!fieldName) return
       const formInput = this.dialog.form[fieldName]
       if (!formInput) return
-      entity[fieldName] = formInput.value
+      formEntity[fieldName] = formInput.value
     })
-    return entity as TEntity
+    return formEntity as TEntity
   }
 
   public validateForm(): boolean {

--- a/src/dialogs/idevsInlineDialog.ts
+++ b/src/dialogs/idevsInlineDialog.ts
@@ -259,7 +259,12 @@ export class IdevsInlineDialog<TEntity = Record<string, unknown>> extends Widget
 
   public async loadNew(): Promise<void> {
     this.dialog.loadNewAndOpenDialog()
-    await this.callPageCallback('onLoad', this.dialog.element as unknown as TEntity)
+    // Pass the (typically empty) current entity, not the Fluent element —
+    // consumers expect an entity-shaped argument matching loadEntity()
+    // and loadById(). Source passed `this.dialog.element` here, which
+    // surfaced a DOM wrapper to onLoad and broke any code that read
+    // entity fields off the argument.
+    await this.callPageCallback('onLoad', this.getEntity())
   }
 
   public async triggerCustomAction(actionName: string, data?: unknown): Promise<unknown> {

--- a/src/dialogs/idevsInlineDialog.ts
+++ b/src/dialogs/idevsInlineDialog.ts
@@ -277,23 +277,47 @@ export class IdevsInlineDialog<TEntity = Record<string, unknown>> extends Widget
   }
 
   public async loadEntity(entity: TEntity): Promise<void> {
-    this.dialog.loadEntityAndOpenDialog(entity)
+    // Wrap the Serenity load call — these methods are synchronous in
+    // Serenity's contract but can throw (e.g., construction failure of
+    // the embedded form). Without the try/catch, a throw would become
+    // an unhandled rejection on the outer Promise; with it, the error
+    // is rethrown after onLoad's best-effort invocation. Callers
+    // awaiting loadEntity get a real rejection they can handle.
+    let loadErr: unknown
+    try {
+      this.dialog.loadEntityAndOpenDialog(entity)
+    } catch (e) {
+      loadErr = e
+    }
     await this.callPageCallback('onLoad', entity)
+    if (loadErr) throw loadErr
   }
 
   public async loadById(id: string | number): Promise<void> {
-    this.dialog.loadByIdAndOpenDialog(id as never)
+    let loadErr: unknown
+    try {
+      this.dialog.loadByIdAndOpenDialog(id as never)
+    } catch (e) {
+      loadErr = e
+    }
     await this.callPageCallback('onLoad', this.getEntity())
+    if (loadErr) throw loadErr
   }
 
   public async loadNew(): Promise<void> {
-    this.dialog.loadNewAndOpenDialog()
     // Pass the (typically empty) current entity, not the Fluent element —
     // consumers expect an entity-shaped argument matching loadEntity()
     // and loadById(). Source passed `this.dialog.element` here, which
     // surfaced a DOM wrapper to onLoad and broke any code that read
     // entity fields off the argument.
+    let loadErr: unknown
+    try {
+      this.dialog.loadNewAndOpenDialog()
+    } catch (e) {
+      loadErr = e
+    }
     await this.callPageCallback('onLoad', this.getEntity())
+    if (loadErr) throw loadErr
   }
 
   public async triggerCustomAction(actionName: string, data?: unknown): Promise<unknown> {

--- a/src/dialogs/idevsPropertyDialog.ts
+++ b/src/dialogs/idevsPropertyDialog.ts
@@ -1,0 +1,66 @@
+import { Decorators, Fluent, PropertyDialog, type WidgetProps } from '@serenity-is/corelib'
+import { setActiveModal, setInactiveModal } from '../helpers/dialogHelpers'
+
+/**
+ * Property-dialog wrapper that integrates with the modal-stack helpers and
+ * dispatches an `onDialogClose` CustomEvent on close. Subclasses override
+ * `setFilterKeys` / `setCriteriaKeys` / `setSearchValue` to receive search-
+ * style context from a parent search button.
+ *
+ * Replaces PowerACC's `CsiPropertyDialog`. The original used PascalCase
+ * assignment-style setters (`dialog.FilterKeys = {...}`); this port exposes
+ * camelCase methods directly (`dialog.setFilterKeys({...})`) — same naming
+ * convention as the editor renames in batches 2-3.
+ */
+@Decorators.registerClass('Idevs.CoreLib.IdevsPropertyDialog')
+export class IdevsPropertyDialog<P = unknown> extends PropertyDialog<unknown, P> {
+  protected customEvent?: CustomEvent
+
+  private _onDataSelected?: (data: unknown) => void
+
+  constructor(props: WidgetProps<P>) {
+    super(props)
+
+    // Tighten the modal header/footer padding — matches PowerACC styling.
+    // Deferred so it runs after Serenity finishes mounting the dialog DOM.
+    setTimeout(() => {
+      const header = this.domNode.parentElement?.querySelector('.modal-header')
+      header?.classList.add('py-1')
+      const footer = this.domNode.parentElement?.querySelector('.modal-footer')
+      footer?.classList.add('py-0')
+    }, 0)
+  }
+
+  // Subclass override hooks (no-ops by default).
+  protected setFilterKeys(_filters: Record<string, unknown>): void {}
+  protected setCriteriaKeys(_criteria: unknown[]): void {}
+  protected setSearchValue(_value: unknown): void {}
+
+  // Selection callback wiring.
+  set onDataSelected(callback: (data: unknown) => void) {
+    this._onDataSelected = callback
+  }
+
+  protected setCustomEvent(detail: unknown): void {
+    this.customEvent = new CustomEvent('onDialogClose', { detail })
+  }
+
+  protected override onDialogOpen(): void {
+    super.onDialogOpen()
+    setInactiveModal(this.domNode)
+  }
+
+  protected override onDialogClose(result?: string): void {
+    if (!this.customEvent) this.setCustomEvent({})
+    this.element[0].dispatchEvent(this.customEvent!)
+    this._onDataSelected?.(this.customEvent!.detail)
+    this.restoreActiveModal()
+    super.onDialogClose(result)
+  }
+
+  private restoreActiveModal(): void {
+    const modal = this.domNode.closest('.modal')
+    const currentLevel = parseInt(Fluent(modal as HTMLElement).data('qrouterorder') ?? '0', 10)
+    setActiveModal(currentLevel)
+  }
+}

--- a/src/dialogs/idevsPropertyDialog.ts
+++ b/src/dialogs/idevsPropertyDialog.ts
@@ -59,8 +59,14 @@ export class IdevsPropertyDialog<P = unknown> extends PropertyDialog<unknown, P>
   }
 
   private restoreActiveModal(): void {
-    const modal = this.domNode.closest('.modal')
-    const currentLevel = parseInt(Fluent(modal as HTMLElement).data('qrouterorder') ?? '0', 10)
+    // Guard against detached DOM (closest can return null when the dialog
+    // is being torn down).
+    const modal = this.domNode.closest<HTMLElement>('.modal')
+    if (!modal) {
+      setActiveModal(0)
+      return
+    }
+    const currentLevel = parseInt(Fluent(modal).data('qrouterorder') ?? '0', 10)
     setActiveModal(currentLevel)
   }
 }

--- a/src/dialogs/idevsPropertyDialog.ts
+++ b/src/dialogs/idevsPropertyDialog.ts
@@ -7,10 +7,14 @@ import { setActiveModal, setInactiveModal } from '../helpers/dialogHelpers'
  * `setFilterKeys` / `setCriteriaKeys` / `setSearchValue` to receive search-
  * style context from a parent search button.
  *
- * Replaces PowerACC's `CsiPropertyDialog`. The original used PascalCase
- * assignment-style setters (`dialog.FilterKeys = {...}`); this port exposes
- * camelCase methods directly (`dialog.setFilterKeys({...})`) — same naming
- * convention as the editor renames in batches 2-3.
+ * Replaces PowerACC's `CsiPropertyDialog`. The preferred API surface is the
+ * camelCase methods (`setFilterKeys`, `setCriteriaKeys`, `setSearchValue`);
+ * the PascalCase assignment setters from PowerACC (`dialog.FilterKeys = ...`)
+ * are PRESERVED as compatibility shims that route to the camelCase methods.
+ * Existing callers — notably IdevsSearchButtonEditor.openDialog which still
+ * writes by assignment per the dialog interface contract — continue to work
+ * unchanged. Subclass overrides on the camelCase methods take effect through
+ * either entry point.
  */
 @Decorators.registerClass('Idevs.CoreLib.IdevsPropertyDialog')
 export class IdevsPropertyDialog<P = unknown> extends PropertyDialog<unknown, P> {
@@ -68,8 +72,15 @@ export class IdevsPropertyDialog<P = unknown> extends PropertyDialog<unknown, P>
 
   protected override onDialogClose(result?: string): void {
     if (!this.customEvent) this.setCustomEvent({})
-    this.element[0].dispatchEvent(this.customEvent!)
-    this._onDataSelected?.(this.customEvent!.detail)
+    const evt = this.customEvent!
+    this.element[0].dispatchEvent(evt)
+    this._onDataSelected?.(evt.detail)
+    // Clear the customEvent after dispatch — without this, a reused dialog
+    // instance can replay stale `detail` on a subsequent close if no new
+    // setCustomEvent was called in the interim (e.g., user cancels after
+    // a prior data selection). Resetting forces the next close to either
+    // explicitly set a payload or fall back to an empty {}.
+    this.customEvent = undefined
     this.restoreActiveModal()
     super.onDialogClose(result)
   }

--- a/src/dialogs/idevsPropertyDialog.ts
+++ b/src/dialogs/idevsPropertyDialog.ts
@@ -31,10 +31,26 @@ export class IdevsPropertyDialog<P = unknown> extends PropertyDialog<unknown, P>
     }, 0)
   }
 
-  // Subclass override hooks (no-ops by default).
-  protected setFilterKeys(_filters: Record<string, unknown>): void {}
-  protected setCriteriaKeys(_criteria: unknown[]): void {}
-  protected setSearchValue(_value: unknown): void {}
+  // Public hooks — subclasses override the implementation; external callers
+  // (notably IdevsSearchButtonEditor's dialog instantiation path) invoke
+  // these to propagate filter/criteria/search context into the dialog.
+  setFilterKeys(_filters: Record<string, unknown>): void {}
+  setCriteriaKeys(_criteria: unknown[]): void {}
+  setSearchValue(_value: unknown): void {}
+
+  // PascalCase property setters — kept as compatibility shims for callers
+  // (e.g., IdevsSearchButtonEditor.openDialog) that still write
+  // `dialog.FilterKeys = {...}` per the PowerACC dialog interface contract.
+  // Route to the camelCase methods so subclass overrides take effect.
+  set FilterKeys(filters: Record<string, unknown>) {
+    this.setFilterKeys(filters)
+  }
+  set CriteriaKeys(criteria: unknown[]) {
+    this.setCriteriaKeys(criteria)
+  }
+  set SearchValue(value: unknown) {
+    this.setSearchValue(value)
+  }
 
   // Selection callback wiring.
   set onDataSelected(callback: (data: unknown) => void) {

--- a/src/dialogs/idevsSearchDialog.ts
+++ b/src/dialogs/idevsSearchDialog.ts
@@ -15,10 +15,16 @@ import { IdevsPropertyDialog } from './idevsPropertyDialog'
  * buttons), and a custom dialog-size option. Subclasses implement
  * `getGrid()` and `getFormKey()`.
  *
- * Replaces PowerACC's `CsiSearchDialog`. PascalCase setters from the source
- * (`set FilterKeys`, `set CriteriaKeys`, `set SearchValue`, `set DialogSize`)
- * are dropped in favor of camelCase methods inherited from the parent + a
- * couple new ones (`setDialogSize`/`setDialogType`/`setDialogPermission`).
+ * Replaces PowerACC's `CsiSearchDialog`. Preferred API: camelCase methods
+ * (`setFilterKeys`, `setCriteriaKeys`, `setSearchValue` inherited from
+ * IdevsPropertyDialog; `setDialogSize`/`setDialogType`/`setDialogPermission`
+ * /`setPreItems` added here). The PowerACC PascalCase assignment setters
+ * (`dialog.FilterKeys = ...`, `dialog.CriteriaKeys = ...`,
+ * `dialog.DialogSize = ...`, `dialog.DialogType = ...`,
+ * `dialog.DialogPermission = ...`, `dialog.preItems = ...`) are PRESERVED
+ * as compatibility shims that route to the camelCase methods. Each routes
+ * through the camelCase method so subclass overrides remain effective via
+ * either entry point.
  */
 
 type GridLike = {

--- a/src/dialogs/idevsSearchDialog.ts
+++ b/src/dialogs/idevsSearchDialog.ts
@@ -75,20 +75,23 @@ export abstract class IdevsSearchDialog<P = unknown> extends IdevsPropertyDialog
   }
 
   // === Override hooks from IdevsPropertyDialog: forward to the grid ===
+  // Public to match the parent's public hook signature (PropertyDialog's
+  // setters are public so external callers — like the editor's dialog
+  // instantiation path — can pass filter/criteria/search context in).
 
-  protected override setFilterKeys(filters: Record<string, unknown>): void {
+  override setFilterKeys(filters: Record<string, unknown>): void {
     const grid = this.getGrid()
     if (grid) grid.FilterKeys = filters
     else super.setFilterKeys(filters)
   }
 
-  protected override setCriteriaKeys(criteria: unknown[]): void {
+  override setCriteriaKeys(criteria: unknown[]): void {
     const grid = this.getGrid()
     if (grid) grid.CriteriaKeys = criteria
     else super.setCriteriaKeys(criteria)
   }
 
-  protected override setSearchValue(value: unknown): void {
+  override setSearchValue(value: unknown): void {
     const grid = this.getGrid()
     if (grid) grid.SearchValue = value
     else super.setSearchValue(value)

--- a/src/dialogs/idevsSearchDialog.ts
+++ b/src/dialogs/idevsSearchDialog.ts
@@ -1,0 +1,182 @@
+import {
+  Authorization,
+  Decorators,
+  type DialogOptions,
+  Fluent,
+  getType,
+  Toolbar,
+  type ToolButton,
+} from '@serenity-is/corelib'
+import { IdevsPropertyDialog } from './idevsPropertyDialog'
+
+/**
+ * Abstract base for "search result" dialogs — extends IdevsPropertyDialog
+ * with a results-grid integration, toolbar customization (clear/new
+ * buttons), and a custom dialog-size option. Subclasses implement
+ * `getGrid()` and `getFormKey()`.
+ *
+ * Replaces PowerACC's `CsiSearchDialog`. PascalCase setters from the source
+ * (`set FilterKeys`, `set CriteriaKeys`, `set SearchValue`, `set DialogSize`)
+ * are dropped in favor of camelCase methods inherited from the parent + a
+ * couple new ones (`setDialogSize`/`setDialogType`/`setDialogPermission`).
+ */
+
+type GridLike = {
+  refresh(): void
+  FilterKeys?: Record<string, unknown>
+  CriteriaKeys?: unknown[]
+  SearchValue?: unknown
+  PreItems?: unknown[]
+  EditPermission?: string
+} & Record<string, unknown>
+
+@Decorators.registerClass('Idevs.CoreLib.IdevsSearchDialog')
+export abstract class IdevsSearchDialog<P = unknown> extends IdevsPropertyDialog<P> {
+  protected abstract getGrid(): GridLike | undefined
+  protected abstract getFormKey(): string
+
+  private _dialogSize?: 'sm' | 'md' | 'lg' | 'xl'
+  private _dialogType?: string
+  private _dialogPermission?: string
+  private _preItems?: unknown[]
+
+  // === Public getters / setters (camelCase methods preferred) ===
+
+  get dialogSize(): 'sm' | 'md' | 'lg' | 'xl' | undefined {
+    return this._dialogSize
+  }
+  setDialogSize(value: 'sm' | 'md' | 'lg' | 'xl'): void {
+    this._dialogSize = value
+  }
+
+  get dialogType(): string | undefined {
+    return this._dialogType
+  }
+  setDialogType(value: string): void {
+    this._dialogType = value
+  }
+
+  get dialogPermission(): string | undefined {
+    return this._dialogPermission
+  }
+  setDialogPermission(value: string): void {
+    this._dialogPermission = value
+    const grid = this.getGrid()
+    if (grid) grid.EditPermission = value
+  }
+
+  get preItems(): unknown[] | undefined {
+    return this._preItems
+  }
+  setPreItems(value: unknown[]): void {
+    this._preItems = value
+    const grid = this.getGrid()
+    if (grid) grid.PreItems = value
+  }
+
+  // === Override hooks from IdevsPropertyDialog: forward to the grid ===
+
+  protected override setFilterKeys(filters: Record<string, unknown>): void {
+    const grid = this.getGrid()
+    if (grid) grid.FilterKeys = filters
+    else super.setFilterKeys(filters)
+  }
+
+  protected override setCriteriaKeys(criteria: unknown[]): void {
+    const grid = this.getGrid()
+    if (grid) grid.CriteriaKeys = criteria
+    else super.setCriteriaKeys(criteria)
+  }
+
+  protected override setSearchValue(value: unknown): void {
+    const grid = this.getGrid()
+    if (grid) grid.SearchValue = value
+    else super.setSearchValue(value)
+  }
+
+  // === Toolbar customization ===
+
+  protected hideToolbar(): boolean {
+    return false
+  }
+
+  initToolbar(): void {
+    setTimeout(() => {
+      this.toolbar = new Toolbar({
+        class: 's-SearchDialogToolbar',
+        buttons: this.getToolbarButtons(),
+      })
+
+      this.removeEmptyToolGroup()
+      const tb = this.domNode.querySelector('.s-Toolbar')
+      if (!tb) return
+      const rendered = this.toolbar.render()
+      while (rendered.firstChild) tb.appendChild(rendered.firstChild)
+    }, 100)
+  }
+
+  protected getToolbarButtons(): ToolButton[] {
+    const buttons = super.getToolbarButtons()
+    if (this.hideToolbar()) return buttons
+
+    buttons.push({
+      icon: 'bi bi-x-lg',
+      hint: 'Clear search',
+      cssClass: 'text-danger d-flex justify-content-center align-items-center',
+      onClick: () => {
+        const inputEl = this.domNode.querySelector<HTMLInputElement>('.s-QuickSearchInput')
+        if (!inputEl) return
+        const searchInput = Fluent(inputEl)
+        searchInput.val('')
+        searchInput.trigger('change')
+      },
+    })
+
+    if (this._dialogType && Authorization.hasPermission(this._dialogPermission ?? '')) {
+      buttons.push({
+        icon: 'bi bi-plus-lg',
+        title: 'New',
+        separator: true,
+        cssClass: 'text-success d-flex justify-content-center align-items-center',
+        onClick: () => {
+          const DialogClass = getType(this._dialogType!) as
+            | (new (...args: unknown[]) => {
+                loadNewAndOpenDialog(triggerEvents?: boolean): void
+                element: [HTMLElement]
+              })
+            | undefined
+          if (!DialogClass) return
+
+          const dlg = new DialogClass({})
+          dlg.loadNewAndOpenDialog(false)
+          dlg.element[0].addEventListener('onDialogClose', (e: Event) => {
+            const data = (e as CustomEvent).detail
+            if (data && Object.keys(data as Record<string, unknown>).length > 0) {
+              this.getGrid()?.refresh()
+            }
+          })
+        },
+      })
+    }
+
+    return buttons
+  }
+
+  protected removeEmptyToolGroup(): void {
+    const elements = this.domNode.getElementsByClassName('tool-group')
+    for (let i = elements.length - 1; i >= 0; i--) {
+      const element = elements[i]
+      // textContent is safer than innerHTML for the emptiness check and avoids
+      // re-parsing.
+      if ((element.textContent ?? '').trim() === '' && element.children.length === 0) {
+        element.parentNode?.removeChild(element)
+      }
+    }
+  }
+
+  protected override getDialogOptions(): DialogOptions {
+    const options = super.getDialogOptions()
+    options.size = this._dialogSize ?? 'md'
+    return options
+  }
+}

--- a/src/dialogs/idevsSearchDialog.ts
+++ b/src/dialogs/idevsSearchDialog.ts
@@ -39,6 +39,9 @@ export abstract class IdevsSearchDialog<P = unknown> extends IdevsPropertyDialog
   private _dialogType?: string
   private _dialogPermission?: string
   private _preItems?: unknown[]
+  /** Tracked initToolbar setTimeout so destroy can cancel it. */
+  private _initToolbarTimer?: ReturnType<typeof setTimeout>
+  private _isSearchDialogDestroyed = false
 
   // === Public getters / setters (camelCase methods preferred) ===
 
@@ -123,7 +126,15 @@ export abstract class IdevsSearchDialog<P = unknown> extends IdevsPropertyDialog
   }
 
   initToolbar(): void {
-    setTimeout(() => {
+    // Cancel any prior pending init (defensive — initToolbar should only
+    // be called once per dialog open, but storing the handle anyway lets
+    // destroy() cancel cleanly).
+    if (this._initToolbarTimer !== undefined) clearTimeout(this._initToolbarTimer)
+    this._initToolbarTimer = setTimeout(() => {
+      this._initToolbarTimer = undefined
+      // Guard against open-then-close races: don't mutate DOM after teardown.
+      if (this._isSearchDialogDestroyed) return
+
       this.toolbar = new Toolbar({
         class: 's-SearchDialogToolbar',
         buttons: this.getToolbarButtons(),
@@ -135,6 +146,15 @@ export abstract class IdevsSearchDialog<P = unknown> extends IdevsPropertyDialog
       const rendered = this.toolbar.render()
       while (rendered.firstChild) tb.appendChild(rendered.firstChild)
     }, 100)
+  }
+
+  override destroy(): void {
+    this._isSearchDialogDestroyed = true
+    if (this._initToolbarTimer !== undefined) {
+      clearTimeout(this._initToolbarTimer)
+      this._initToolbarTimer = undefined
+    }
+    super.destroy()
   }
 
   protected getToolbarButtons(): ToolButton[] {

--- a/src/dialogs/idevsSearchDialog.ts
+++ b/src/dialogs/idevsSearchDialog.ts
@@ -68,6 +68,25 @@ export abstract class IdevsSearchDialog<P = unknown> extends IdevsPropertyDialog
   get preItems(): unknown[] | undefined {
     return this._preItems
   }
+  // === PascalCase compatibility shims ===
+  // IdevsSearchButtonEditor.openDialog writes these by property assignment
+  // per the PowerACC dialog interface contract. Without a setter pair,
+  // (a) DialogSize/Type/Permission writes silently no-op, and
+  // (b) `preItems` assignment THROWS in strict mode (getter-only).
+  // Each setter routes to the camelCase method so subclass overrides
+  // remain effective.
+  set DialogSize(value: 'sm' | 'md' | 'lg' | 'xl') {
+    this.setDialogSize(value)
+  }
+  set DialogType(value: string) {
+    this.setDialogType(value)
+  }
+  set DialogPermission(value: string) {
+    this.setDialogPermission(value)
+  }
+  set preItems(value: unknown[]) {
+    this.setPreItems(value)
+  }
   setPreItems(value: unknown[]): void {
     this._preItems = value
     const grid = this.getGrid()

--- a/src/dialogs/idevsSearchDialog.ts
+++ b/src/dialogs/idevsSearchDialog.ts
@@ -197,12 +197,20 @@ export abstract class IdevsSearchDialog<P = unknown> extends IdevsPropertyDialog
 
           const dlg = new DialogClass({})
           dlg.loadNewAndOpenDialog(false)
-          dlg.element[0].addEventListener('onDialogClose', (e: Event) => {
-            const data = (e as CustomEvent).detail
-            if (data && Object.keys(data as Record<string, unknown>).length > 0) {
-              this.getGrid()?.refresh()
-            }
-          })
+          // `{ once: true }` so each click of the "New" toolbar button
+          // produces ONE listener. Without it, opening "New" N times
+          // accumulated N listeners on dlg.element[0], firing N grid
+          // refreshes on the next close.
+          dlg.element[0].addEventListener(
+            'onDialogClose',
+            (e: Event) => {
+              const data = (e as CustomEvent).detail
+              if (data && Object.keys(data as Record<string, unknown>).length > 0) {
+                this.getGrid()?.refresh()
+              }
+            },
+            { once: true },
+          )
         },
       })
     }

--- a/src/dialogs/index.ts
+++ b/src/dialogs/index.ts
@@ -1,0 +1,4 @@
+export * from './idevsPropertyDialog'
+export * from './idevsEntityDialog'
+export * from './idevsInlineDialog'
+export * from './idevsSearchDialog'

--- a/src/helpers/dialogHelpers.ts
+++ b/src/helpers/dialogHelpers.ts
@@ -22,12 +22,21 @@ export type IDialogSize = {
 
 /**
  * Use within `onDialogOpen()` AFTER the super call. Sizes the modal dialog
- * matching the class's `.s-<ClassName>` selector to the supplied width/height
- * (or measured height when not specified) and centers it on the viewport.
+ * to the supplied width/height (or measured height when not specified) and
+ * centers it on the viewport.
+ *
+ * Selector source (in priority order):
+ *   1. `opt.selector` if supplied — preferred; immune to minification.
+ *   2. `.s-<className>` derived from `dialog.constructor.name` — preserves
+ *      PowerACC source behavior, but **breaks under JS minification**
+ *      (class names mangle to `t`, `Y`, etc.). Production consumers using
+ *      a minifier should pass `opt.selector` explicitly.
  */
-export function setDialogSize(dialog: object, opt?: IDialogSize): void {
-  const className = dialog.constructor.name
-  const name = `.s-${className}`
+export function setDialogSize(
+  dialog: object,
+  opt?: IDialogSize & { selector?: string },
+): void {
+  const name = opt?.selector ?? `.s-${dialog.constructor.name}`
   const optionH = opt?.height ?? 0
   const measuredH = ($(`${name} .modal-dialog`).innerHeight() ?? 0) as number
   const h = optionH > 0 ? optionH : measuredH
@@ -385,10 +394,26 @@ export function addSearchButton<F extends PrefixedContext>(options: SearchDialog
       dlg.FilterKey = filterField?.value
     }
     dlg.dialogOpen()
-    dlg.element[0].addEventListener('onDialogClose', (e: Event) => {
-      const detail = (e as CustomEvent).detail
-      options.callback(options.form, detail)
-    })
+    // `{ once: true }` so the listener removes itself after firing once.
+    // Without it, every button click added a fresh listener — opening
+    // and closing the dialog N times would invoke the consumer's
+    // callback N times on the (N+1)th close.
+    // Wrapped in try/catch so a thrown consumer callback can't bubble
+    // into Bootstrap/jQuery's event dispatch (which can leave the
+    // dialog in an inconsistent state).
+    dlg.element[0].addEventListener(
+      'onDialogClose',
+      (e: Event) => {
+        const detail = (e as CustomEvent).detail
+        try {
+          options.callback(options.form, detail)
+        } catch {
+          /* Consumer callback errors should not corrupt dialog teardown.
+           * Swallow here; Serenity's own onError pathways surface details. */
+        }
+      },
+      { once: true },
+    )
   }
 }
 

--- a/src/helpers/dialogHelpers.ts
+++ b/src/helpers/dialogHelpers.ts
@@ -1,0 +1,404 @@
+import { Fluent, Toolbar, type PrefixedContext } from '@serenity-is/corelib'
+
+/**
+ * Generic dialog/modal helpers ported from PowerACC's Dialogs.ts. The
+ * existing `dialogHelper.ts` (singular) hosts the DialogHelper class and a
+ * handful of validators/utilities; this file (plural) adds the rest of the
+ * PowerACC-generic helpers without disturbing the existing module.
+ *
+ * PowerACC's domain-specific parameter types (RequestApprovalParameter,
+ * BookingRequestApprovalParameter, RequestPrintShippingMarkParameter, etc.)
+ * are intentionally NOT ported — they belong in PowerACC's app code.
+ */
+
+// ──────────────────────────────────────────────────────────────────────────
+// Dialog sizing
+// ──────────────────────────────────────────────────────────────────────────
+
+export type IDialogSize = {
+  width?: number
+  height?: number
+}
+
+/**
+ * Use within `onDialogOpen()` AFTER the super call. Sizes the modal dialog
+ * matching the class's `.s-<ClassName>` selector to the supplied width/height
+ * (or measured height when not specified) and centers it on the viewport.
+ */
+export function setDialogSize(dialog: object, opt?: IDialogSize): void {
+  const className = dialog.constructor.name
+  const name = `.s-${className}`
+  const optionH = opt?.height ?? 0
+  const measuredH = ($(`${name} .modal-dialog`).innerHeight() ?? 0) as number
+  const h = optionH > 0 ? optionH : measuredH
+  const w = opt?.width ?? 420
+  $(name)
+    .css({ width: `${w}px`, height: `${h}px` })
+    .position({
+      of: window,
+      my: 'center center',
+      at: 'center center',
+    })
+}
+
+/**
+ * Wire a touchstart-to-click handler on every close button matching
+ * `<cssClass> .ui-dialog-titlebar-close`. Workaround for older mobile
+ * browsers where the titlebar close button needs an explicit synthetic click.
+ */
+export function fixMobileCloseDialog(cssClass: string): void {
+  cssClass = cssClass.trim()
+  cssClass = `${cssClass[0] === '.' ? '' : '.'}${cssClass}`
+  document.querySelectorAll(`${cssClass} .ui-dialog-titlebar-close`).forEach(el => {
+    ;(el as HTMLElement).addEventListener('touchstart', evt => {
+      const btn = evt.target as HTMLElement | null
+      btn?.click()
+    })
+  })
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Field grouping
+// ──────────────────────────────────────────────────────────────────────────
+
+/**
+ * Group fields together in a single wrapper div. Each tuple is
+ * `[fieldClassName, colWidthClassesToApply]`. The first tuple's class
+ * + '_group' becomes the wrapper class. Idempotent (no-op when the wrapper
+ * already exists).
+ */
+export function groupFields(
+  domNode: HTMLElement,
+  classNames: [string, string][],
+  groupCssClass: string,
+): void {
+  const elements: HTMLElement[] = classNames
+    .map(([cls]) => domNode.querySelector<HTMLElement>(`.${cls}`))
+    .filter((el): el is HTMLElement => el !== null)
+
+  // Bail if any of the requested fields weren't found.
+  if (elements.length !== classNames.length) return
+
+  const groupName = `${classNames[0][0]}_group`
+  const existing = domNode.querySelector<HTMLElement>(`.${groupName}`)
+  if (existing) return
+
+  const groupDiv = document.createElement('div')
+  groupDiv.classList.add('field', 'p-0', groupName, ...groupCssClass.split(' ').filter(Boolean))
+
+  const rootElement = elements[0].parentElement
+  if (!rootElement) return
+  rootElement.insertBefore(groupDiv, elements[0])
+
+  classNames.forEach(([, colWidth], index) => {
+    const element = elements[index]
+    // Strip any existing col-* classes
+    Array.from(element.classList)
+      .filter(c => c.startsWith('col-'))
+      .forEach(c => element.classList.remove(c))
+    // Apply requested col classes
+    element.classList.add(...colWidth.split(' ').filter(Boolean))
+    groupDiv.appendChild(element)
+  })
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Modal stack (active/inactive layering)
+// ──────────────────────────────────────────────────────────────────────────
+
+/**
+ * Restore the most-recently-active modal at or below `currentLevel` by
+ * removing its `modal-inactive` class. Inputs are HTML elements stamped
+ * with `data-qrouterorder` indicating their nesting depth.
+ */
+export function setActiveModal(currentLevel: number): void {
+  let previousDialog: HTMLElement | undefined
+  let maxOrder = -1
+  document.querySelectorAll<HTMLElement>('.modal[data-qrouterorder]').forEach(el => {
+    const level = parseInt(Fluent(el).attr('data-qrouterorder') ?? '0', 10)
+    if (level < currentLevel && level > maxOrder) {
+      maxOrder = level
+      previousDialog = el
+    }
+  })
+  previousDialog?.classList.remove('modal-inactive')
+}
+
+/**
+ * Mark all modals below `currentModel`'s level as `modal-inactive`. If
+ * `includeCurrent` is true, also marks the current model. Deferred by 100ms
+ * to match PowerACC's source behavior (allows the new modal to mount first).
+ */
+export function setInactiveModal(currentModel: HTMLElement, includeCurrent?: boolean): void {
+  if (!currentModel.classList.contains('modal-body')) return
+
+  setTimeout(() => {
+    const parent = currentModel.closest('.modal')
+    if (!parent) return
+    const currentLevel = parseInt(Fluent(parent).attr('data-qrouterorder') ?? '0', 10)
+    document.querySelectorAll<HTMLElement>('.modal[data-qrouterorder]').forEach(el => {
+      const level = parseInt(Fluent(el).attr('data-qrouterorder') ?? '0', 10)
+      if (level < currentLevel && !el.classList.contains('modal-inactive')) {
+        Fluent(el).addClass('modal-inactive')
+      }
+      if (includeCurrent) (parent as HTMLElement).classList.add('modal-inactive')
+    })
+  }, 100)
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Radio-button enable/disable
+// ──────────────────────────────────────────────────────────────────────────
+
+export function disableRadioButtons(element: HTMLElement): void {
+  element.querySelectorAll<HTMLElement>('.s-RadioButtonEditor').forEach(field => {
+    field.setAttribute('disabled', 'disabled')
+    field.querySelectorAll<HTMLInputElement>("input[type='radio']").forEach(child => {
+      child.setAttribute('disabled', 'disabled')
+    })
+  })
+}
+
+export function enableRadioButtons(element: HTMLElement): void {
+  element.querySelectorAll<HTMLElement>('.s-RadioButtonEditor').forEach(field => {
+    field.removeAttribute('disabled')
+    field.querySelectorAll<HTMLInputElement>("input[type='radio']").forEach(child => {
+      child.removeAttribute('disabled')
+    })
+  })
+}
+
+export function enableRadioButtonEditor(element: HTMLElement): void {
+  element.removeAttribute('disabled')
+  element.querySelectorAll<HTMLInputElement>("input[type='radio']").forEach(child => {
+    child.removeAttribute('disabled')
+  })
+}
+
+export function disableRadioButtonEditor(element: HTMLElement): void {
+  element.setAttribute('disabled', 'disabled')
+  element.querySelectorAll<HTMLInputElement>("input[type='radio']").forEach(child => {
+    child.setAttribute('disabled', 'disabled')
+  })
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Generic editor enable/disable
+// ──────────────────────────────────────────────────────────────────────────
+
+type ReadOnlyEditor = { set_readOnly(value: boolean): void }
+
+function trySetReadOnly(element: HTMLElement, readOnly: boolean): boolean {
+  const widget = Fluent(element).getWidget() as ReadOnlyEditor | undefined
+  if (widget && typeof widget.set_readOnly === 'function') {
+    widget.set_readOnly(readOnly)
+    return true
+  }
+  return false
+}
+
+/**
+ * Enable an editor by class-based detection. Handles RadioButtonEditor,
+ * IdevsSearchButtonEditor (`.s-IdevsSearchButtonEditor`), IdevsTagEditor
+ * (`.s-IdevsTagEditor`), IdevsNumericTagEditor, plus a generic
+ * remove-readonly fallback. Special-cases IdevsDateEditor's trigger-button
+ * opacity.
+ */
+export function enableEditor(element: HTMLElement): void {
+  if (element.classList.contains('s-RadioButtonEditor')) {
+    enableRadioButtonEditor(element)
+  } else if (
+    element.classList.contains('s-IdevsSearchButtonEditor') ||
+    element.classList.contains('s-IdevsSelfSearchButtonEditor') ||
+    element.classList.contains('s-IdevsTagEditor') ||
+    element.classList.contains('s-IdevsNumericTagEditor') ||
+    // Legacy class names from PowerACC's Csi* editors — retained for
+    // migration period; can be removed once consumers update.
+    element.classList.contains('s-SearchButtonEditor') ||
+    element.classList.contains('s-TagEditor') ||
+    element.classList.contains('s-NumericTagEditor')
+  ) {
+    trySetReadOnly(element, false)
+  } else {
+    element.classList.remove('readonly')
+    element.removeAttribute('readonly')
+  }
+
+  // IdevsDateEditor: restore the trigger button opacity.
+  if (
+    element.classList.contains('s-IdevsDateEditor') ||
+    element.classList.contains('s-DateEditor') ||
+    element.classList.contains('s-CsiDateEditor')
+  ) {
+    const btn = element.parentElement?.querySelector<HTMLElement>('.ui-datepicker-trigger')
+    btn?.style.removeProperty('opacity')
+  }
+}
+
+export function disableEditor(element: HTMLElement): void {
+  if (element.classList.contains('s-RadioButtonEditor')) {
+    disableRadioButtonEditor(element)
+  } else if (
+    element.classList.contains('s-IdevsSearchButtonEditor') ||
+    element.classList.contains('s-IdevsSelfSearchButtonEditor') ||
+    element.classList.contains('s-IdevsTagEditor') ||
+    element.classList.contains('s-IdevsNumericTagEditor') ||
+    element.classList.contains('s-SearchButtonEditor') ||
+    element.classList.contains('s-SelfSearchButtonEditor') ||
+    element.classList.contains('s-TagEditor') ||
+    element.classList.contains('s-NumericTagEditor')
+  ) {
+    trySetReadOnly(element, true)
+  } else {
+    element.classList.add('readonly')
+    element.setAttribute('readonly', 'readonly')
+  }
+
+  if (
+    element.classList.contains('s-IdevsDateEditor') ||
+    element.classList.contains('s-DateEditor') ||
+    element.classList.contains('s-CsiDateEditor')
+  ) {
+    const btn = element.parentElement?.querySelector<HTMLElement>('.ui-datepicker-trigger')
+    if (btn) btn.style.opacity = '0.1'
+  }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Toolbar button state
+// ──────────────────────────────────────────────────────────────────────────
+
+export function disableToolbarButton(toolbar: Toolbar, buttonCssClass: string): void {
+  const button = toolbar.findButton(buttonCssClass)
+  if (!button) return
+  setTimeout(() => {
+    button.addClass('disabled')
+    button.attr('disabled', 'disabled')
+  }, 0)
+}
+
+export function enableToolbarButton(toolbar: Toolbar, buttonCssClass: string): void {
+  const button = toolbar.findButton(buttonCssClass)
+  if (!button) return
+  setTimeout(() => {
+    button.removeClass('disabled')
+    button.removeAttr('disabled')
+  }, 0)
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Input validation message
+// ──────────────────────────────────────────────────────────────────────────
+
+/**
+ * Toggle an inline error message next to a form field. The PowerACC source
+ * used `innerHTML` to build the error label (XSS vector if the message
+ * comes from user input); this port uses DOM API + textContent.
+ */
+export function toggleInputValidateMessage(
+  form: PrefixedContext,
+  fieldName: string,
+  message: string,
+): void {
+  const input = (form as unknown as Record<string, { domNode: HTMLInputElement }>)[fieldName]
+    ?.domNode
+  if (!input) return
+  const sibling = input.nextElementSibling
+  if (!sibling) return
+
+  if (message) {
+    input.classList.remove('valid')
+    input.classList.add('error')
+    // Clear existing content; rebuild via DOM API (no innerHTML).
+    while (sibling.firstChild) sibling.removeChild(sibling.firstChild)
+    const label = document.createElement('label')
+    label.classList.add('error')
+    label.setAttribute('id', `${input.id}-error`)
+    label.setAttribute('for', input.id)
+    label.setAttribute('title', `${message}.`)
+    label.textContent = `${message}.`
+    sibling.appendChild(label)
+  } else {
+    input.classList.remove('error')
+    input.classList.add('valid')
+    while (sibling.firstChild) sibling.removeChild(sibling.firstChild)
+  }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Search button wiring
+// ──────────────────────────────────────────────────────────────────────────
+
+export type SearchDialogOptions<F extends PrefixedContext> = {
+  form: F
+  fieldName: keyof F
+  buttonClass: string
+  filterKey?: string
+  dialogClass: new (P: Record<string, unknown>) => {
+    dialogOpen(): void
+    element: [HTMLElement]
+    FilterKey?: unknown
+  }
+  callback: (form: F, data: unknown) => void
+}
+
+/**
+ * Add an in-place search button to a form field. Clicking the button opens
+ * the supplied dialog class; when the dialog closes with detail data, the
+ * callback fires with the form and detail. Idempotent (no-op when the
+ * button class already exists on the page).
+ */
+export function addSearchButton<F extends PrefixedContext>(options: SearchDialogOptions<F>): void {
+  if (document.querySelector(`.${options.buttonClass}`)) return
+
+  const fieldHolder = (options.form as unknown as Record<string, { domNode: HTMLElement }>)[
+    options.fieldName as string
+  ]
+  if (!fieldHolder?.domNode?.parentElement) return
+
+  const btn = document.createElement('button')
+  btn.setAttribute('type', 'button')
+  btn.classList.add('inplace-button', options.buttonClass)
+  btn.setAttribute('aria-label', 'Search')
+
+  const icon = document.createElement('i')
+  icon.classList.add('bi', 'bi-search')
+  btn.appendChild(icon)
+
+  const ref = fieldHolder.domNode.parentElement.querySelector('.vx')
+  fieldHolder.domNode.parentElement.insertBefore(btn, ref)
+
+  btn.onclick = () => {
+    const dlg = new options.dialogClass({})
+    if (options.filterKey) {
+      const filterField = (options.form as unknown as Record<string, { value: unknown }>)[
+        options.filterKey
+      ]
+      dlg.FilterKey = filterField?.value
+    }
+    dlg.dialogOpen()
+    dlg.element[0].addEventListener('onDialogClose', (e: Event) => {
+      const detail = (e as CustomEvent).detail
+      options.callback(options.form, detail)
+    })
+  }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Dialog event constants
+// ──────────────────────────────────────────────────────────────────────────
+
+/**
+ * Standard dialog event names dispatched on the dialog's root element via
+ * `CustomEvent`. Renamed from PowerACC's `CsiDialogEventName`.
+ */
+export class IdevsDialogEventName {
+  static readonly DialogOpen = 'onDialogOpen'
+  static readonly DialogClose = 'onDialogClose'
+  static readonly DialogSave = 'onDialogSave'
+  static readonly DialogDelete = 'onDialogDelete'
+}
+
+export function createCustomEvent<T = unknown>(eventName: string, detail: T): CustomEvent<T> {
+  return new CustomEvent<T>(eventName, { detail })
+}

--- a/src/helpers/dialogHelpers.ts
+++ b/src/helpers/dialogHelpers.ts
@@ -349,12 +349,20 @@ export type SearchDialogOptions<F extends PrefixedContext> = {
  * button class already exists on the page).
  */
 export function addSearchButton<F extends PrefixedContext>(options: SearchDialogOptions<F>): void {
-  if (document.querySelector(`.${options.buttonClass}`)) return
-
   const fieldHolder = (options.form as unknown as Record<string, { domNode: HTMLElement }>)[
     options.fieldName as string
   ]
   if (!fieldHolder?.domNode?.parentElement) return
+
+  const fieldParent = fieldHolder.domNode.parentElement
+
+  // Idempotency check scoped to THIS field's parent (was document-global).
+  // Multiple forms/dialogs sharing a buttonClass — common when the same
+  // search-button helper is wired up on every customer/order form on a
+  // page — would have left every form after the first one without a
+  // button. The scoped check still prevents double-injection on the
+  // target field while allowing siblings to receive their own button.
+  if (fieldParent.querySelector(`.${options.buttonClass}`)) return
 
   const btn = document.createElement('button')
   btn.setAttribute('type', 'button')
@@ -365,8 +373,8 @@ export function addSearchButton<F extends PrefixedContext>(options: SearchDialog
   icon.classList.add('bi', 'bi-search')
   btn.appendChild(icon)
 
-  const ref = fieldHolder.domNode.parentElement.querySelector('.vx')
-  fieldHolder.domNode.parentElement.insertBefore(btn, ref)
+  const ref = fieldParent.querySelector('.vx')
+  fieldParent.insertBefore(btn, ref)
 
   btn.onclick = () => {
     const dlg = new options.dialogClass({})

--- a/src/helpers/filterHelper.ts
+++ b/src/helpers/filterHelper.ts
@@ -1,0 +1,23 @@
+import { EditorUtils, Fluent, type QuickFilter, type Widget } from '@serenity-is/corelib'
+
+/**
+ * Filter-criteria helpers for Serenity QuickFilter chains.
+ */
+
+/**
+ * Reset all LookupEditor quick filters to null and strip the active marker.
+ * Other editor types are left alone (the source only special-cased
+ * LookupEditor; if non-lookup filter reset is needed, add per-type
+ * handling here).
+ */
+export function clearFilter(filters: QuickFilter<Widget<unknown>, unknown>[]): void {
+  for (const filter of filters) {
+    if (!filter.type || filter.type.name !== 'LookupEditor') continue
+    const el = document.querySelector<HTMLInputElement>(`input[id*="_QuickFilter_${filter.field}"]`)
+    if (!el) continue
+    const widget = Fluent(el).getWidget(filter.type)
+    EditorUtils.setValue(widget, null)
+    const root = el.closest('.quick-filter-item')
+    root?.classList.remove('quick-filter-active')
+  }
+}

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -1,6 +1,34 @@
 export * from './dialogHelper'
+export * from './dialogHelpers'
+export * from './filterHelper'
 export * from './gridHelper'
 export * from './excelExportHelper'
+// layoutHelper: explicit export to avoid getElementHeight clash with utils/dom.ts
+// (utils/dom has a synchronous variant; layoutHelper has an async polling variant).
+export {
+  createLayout,
+  addElementGroup,
+  createGroup,
+  addElements,
+  addElementsWithEmptyElement,
+  setTabIndex,
+  groupColumnHeader,
+  groupHeaderColumns,
+  getColumnHeaderHeight,
+  getElementHeight as waitForElementHeight,
+  getTargetElement,
+  createDivWithClassesAndAppendBefore,
+  createDivWithClassesAndAppendAfter,
+  createDivWithClassesAndAppendTo,
+  moveDivToNewParent,
+  moveDivsToNewParent,
+  labelCaptionTopLeft,
+  labelCaptionTopRight,
+  applyCSS,
+  addCssClassToField,
+  toggleButtonInForm,
+  toggleButton,
+} from './layoutHelper'
 export { doExportPdf } from './pdfExportHelper'
 export * from './processQueryButtons'
 export * from './windowHelper'

--- a/src/helpers/layoutHelper.ts
+++ b/src/helpers/layoutHelper.ts
@@ -229,7 +229,13 @@ export function groupColumnHeader(
   height = height ?? headerRect?.height ?? 0
 
   const columns: string[] = [columnName]
-  let targetColumn = domNode.querySelector<HTMLElement>(`[id$=${columnName}]`)
+  // Escape `columnName` for CSS attribute selector safety — column names
+  // can include characters that need quoting (or break the selector
+  // entirely). CSS.escape handles all required cases.
+  const escapedColumnName = typeof CSS !== 'undefined' && CSS.escape
+    ? CSS.escape(columnName)
+    : columnName.replace(/(["\\[\]])/g, '\\$1')
+  let targetColumn = domNode.querySelector<HTMLElement>(`[id$="${escapedColumnName}"]`)
   if (!targetColumn) return
   const prefix = (targetColumn.getAttribute('id') ?? '').replace(columnName, '')
   let width = targetColumn.getClientRects().item(0)?.width ?? 0
@@ -290,7 +296,14 @@ export function groupColumnHeader(
     } else {
       child.findFirst('.slick-resizable-handle')?.remove()
       if (childName !== columnName) {
-        document.querySelector(`#${prefix}${childName}`)?.addEventListener('click', (evt: Event) => {
+        // Scope the lookup to this grid's domNode (was `document.querySelector`
+        // — would bind to the WRONG grid when multiple SlickGrids share id
+        // prefixes). Also escape the constructed id for CSS-selector safety.
+        const escapedId =
+          typeof CSS !== 'undefined' && CSS.escape
+            ? CSS.escape(`${prefix}${childName}`)
+            : `${prefix}${childName}`.replace(/(["\\[\]])/g, '\\$1')
+        domNode.querySelector(`#${escapedId}`)?.addEventListener('click', (evt: Event) => {
           evt.preventDefault()
           evt.stopPropagation()
           return false

--- a/src/helpers/layoutHelper.ts
+++ b/src/helpers/layoutHelper.ts
@@ -1,0 +1,496 @@
+import { Fluent, Toolbar } from '@serenity-is/corelib'
+
+/**
+ * DOM/layout helpers ported from PowerACC's LayoutHelper. The PowerACC source
+ * attached the first 7 of these as prototype extensions on `HTMLElement`
+ * (e.g., `element.createLayout(...)`). They are exposed here as plain
+ * functions to avoid polluting the global prototype:
+ *
+ *   // PowerACC:
+ *   element.createLayout(3, 'col')
+ *
+ *   // idevs.corelib:
+ *   import { createLayout } from '@idevs/corelib/helpers'
+ *   createLayout(element, 3, 'col')
+ *
+ * Behavioral parity is preserved otherwise.
+ */
+
+// ──────────────────────────────────────────────────────────────────────────
+// Converted from PowerACC prototype extensions
+// ──────────────────────────────────────────────────────────────────────────
+
+/**
+ * Insert `columns` div children into `parent`, optionally anchored before/
+ * after a reference child matched by `refChildCssClass`. The returned array
+ * is in left-to-right order.
+ */
+export function createLayout(
+  parent: HTMLElement,
+  columns: number,
+  cssClass: string | string[],
+  refChildCssClass?: string,
+): HTMLElement[] {
+  const divCollection: HTMLElement[] = []
+  let isAfter: boolean
+  let refChild: ChildNode | Element | null
+
+  if (refChildCssClass) {
+    refChild = parent.querySelector(`.${refChildCssClass}`)
+    isAfter = !!refChild
+  } else {
+    refChild = parent.firstChild
+    isAfter = false
+  }
+
+  const insertBeforeReference = (div: HTMLElement) => {
+    parent.insertBefore(div, refChild as Node | null)
+  }
+  const insertAfterReference = (div: HTMLElement) => {
+    parent.insertBefore(div, (refChild as ChildNode | null)?.nextSibling ?? null)
+  }
+
+  for (let i = 0; i < columns; i++) {
+    const div = document.createElement('div')
+    if (Array.isArray(cssClass)) {
+      div.className = i > cssClass.length - 1 ? cssClass[cssClass.length - 1] : cssClass[i]
+    } else {
+      div.className = cssClass
+    }
+    divCollection.push(div)
+
+    if (isAfter) {
+      insertAfterReference(div)
+      refChild = div
+    } else {
+      if (i === 0) insertBeforeReference(div)
+      else insertAfterReference(div)
+      refChild = div
+    }
+  }
+
+  return divCollection
+}
+
+/**
+ * Create a new div wrapper inside `parent`, gathering elements either by
+ * CSS-class lookup against `source` (string arg) or by direct reference
+ * (HTMLElement arg). Returns the new wrapper.
+ */
+export function addElementGroup(
+  parent: HTMLElement,
+  source: HTMLElement,
+  cssClass: string,
+  ...args: Array<HTMLElement | string>
+): HTMLElement {
+  const div = document.createElement('div')
+  if (cssClass) div.className = cssClass
+
+  for (const arg of args) {
+    if (typeof arg === 'string') {
+      const selectors = arg.split(',').map(c => `:scope .${c.trim()}`).join(', ')
+      source.querySelectorAll<HTMLElement>(selectors).forEach(el => div.appendChild(el))
+    } else {
+      div.appendChild(arg)
+    }
+  }
+
+  parent.appendChild(div)
+  return div
+}
+
+/**
+ * Create a new div, optionally gathering children matching `target` (a
+ * comma-separated CSS-class list) from `source`. Returns the new div
+ * without appending it anywhere.
+ */
+export function createGroup(
+  source: HTMLElement,
+  cssClass?: string,
+  target?: string,
+): HTMLElement {
+  const div = document.createElement('div')
+  if (cssClass) div.className = cssClass
+  if (target) {
+    const selectors = target.split(',').map(c => `:scope .${c.trim()}`).join(', ')
+    source.querySelectorAll<HTMLElement>(selectors).forEach(el => div.appendChild(el))
+  }
+  return div
+}
+
+/**
+ * Append elements (or class-matched elements) into `parent`.
+ */
+export function addElements(
+  parent: HTMLElement,
+  source: HTMLElement,
+  ...args: Array<HTMLElement | string>
+): void {
+  for (const arg of args) {
+    if (typeof arg === 'string') {
+      const selectors = arg.split(',').map(c => `:scope .${c.trim()}`).join(', ')
+      source.querySelectorAll<HTMLElement>(selectors).forEach(t => parent.appendChild(t))
+    } else {
+      parent.appendChild(arg)
+    }
+  }
+}
+
+/**
+ * Append elements + pad with `emptyCount` empty `.field` divs.
+ */
+export function addElementsWithEmptyElement(
+  parent: HTMLElement,
+  source: HTMLElement,
+  emptyCount: number,
+  ...args: Array<HTMLElement | string>
+): void {
+  addElements(parent, source, ...args)
+  for (let i = 0; i < emptyCount; i++) {
+    const div = document.createElement('div')
+    div.classList.add('field')
+    parent.appendChild(div)
+  }
+}
+
+/**
+ * Assign sequential `tabindex` values to inputs within each field. Handles
+ * radio (`label > input`), textarea (`div > textarea`), normal inputs
+ * (`div > input`), and DropdownEditor (anchor-wrapped input with
+ * `tabindex="-1"`). Returns the next available tab index.
+ */
+export function setTabIndex(
+  scope: HTMLElement,
+  startIdx: number,
+  ...args: Array<HTMLElement | string>
+): number {
+  let idx = startIdx
+
+  const apply = (target: HTMLElement, currentIdx: number): number => {
+    let el = target.querySelector<HTMLElement>('label > input')
+    if (el) {
+      el.setAttribute('tabindex', currentIdx.toString())
+      return currentIdx + 1
+    }
+    el = target.querySelector<HTMLElement>('div > textarea')
+    if (el) {
+      el.setAttribute('tabindex', currentIdx.toString())
+      return currentIdx + 1
+    }
+    el = target.querySelector<HTMLElement>('div > input')
+    if (!el) return currentIdx
+    const existing = el.getAttribute('tabindex')
+    if (existing === '-1') {
+      const inner = target.querySelector<HTMLElement>('a > input')
+      if (inner) el = inner
+    }
+    el.setAttribute('tabindex', currentIdx.toString())
+    return currentIdx + 1
+  }
+
+  for (const arg of args) {
+    if (typeof arg === 'string') {
+      const selectors = arg.split(',').map(c => `.${c.trim()}`).join(', ')
+      scope.querySelectorAll<HTMLElement>(selectors).forEach(target => {
+        idx = apply(target, idx)
+      })
+    } else {
+      idx = apply(arg, idx)
+    }
+  }
+  return idx
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// SlickGrid column header utilities
+// ──────────────────────────────────────────────────────────────────────────
+
+/**
+ * Group `columnCount` adjacent SlickGrid columns under a shared header
+ * titled `title`. The `columnName` argument identifies the first column;
+ * subsequent siblings are pulled in until `columnCount` is reached.
+ *
+ * NOTE: this manipulates SlickGrid's internal DOM (`.slick-header`,
+ * `.slick-header-columns`, `.slick-header-column`, `.slick-resizable-handle`).
+ * Behavior may change if SlickGrid's DOM structure changes upstream.
+ */
+export function groupColumnHeader(
+  domNode: HTMLElement,
+  title: string,
+  columnName: string,
+  columnCount: number,
+  height: number,
+): void {
+  const gridHeader = domNode.querySelector<HTMLElement>('.slick-header')
+  if (!gridHeader) return
+  const headerColumns = gridHeader.querySelector<HTMLElement>('.slick-header-columns')
+  if (!headerColumns) return
+  const headerRect = headerColumns.getClientRects().item(0)
+  height = height ?? headerRect?.height ?? 0
+
+  const columns: string[] = [columnName]
+  let targetColumn = domNode.querySelector<HTMLElement>(`[id$=${columnName}]`)
+  if (!targetColumn) return
+  const prefix = (targetColumn.getAttribute('id') ?? '').replace(columnName, '')
+  let width = targetColumn.getClientRects().item(0)?.width ?? 0
+
+  for (let i = 0; i < columnCount - 1; i++) {
+    const next = targetColumn.nextElementSibling as HTMLElement | null
+    if (next) {
+      const name = (next.getAttribute('id') ?? '').replace(prefix, '')
+      columns.push(name)
+      width += next.getClientRects().item(0)?.width ?? 0
+      targetColumn = next
+    }
+  }
+
+  const prev = targetColumn.previousElementSibling as HTMLElement | null
+  const newColumn = Fluent('div')
+    .attr('id', `${columnName}Group`)
+    .class(['slick-header-column', 'ui-state-default', 'd-flex', 'flex-column', 'px-0'])
+    .attr('data-id', columnName)
+    .attr('draggable', 'false')
+    .style(css => {
+      css.width = `${width}px`
+    })
+    .insertBefore(prev as HTMLElement)
+
+  // Title row — text via textContent (no innerHTML)
+  const titleEl = Fluent('div')
+    .style(css => {
+      css.height = `${height - 1}px`
+      css.borderBottom = '2px solid #ddd'
+    })
+    .class(['w-100', 'text-center'])
+    .attr('draggable', 'false')
+    .attr('id', `${columnName}GroupTitle`)
+    .appendTo(newColumn)
+    .getNode()
+  titleEl.textContent = title
+
+  const groupPanel = Fluent('div')
+    .class(['w-100', 'h-100', 'd-flex', 'align-items-center'])
+    .attr('draggable', 'false')
+    .appendTo(newColumn)
+
+  Array.from(headerColumns.children).forEach((c: Element) => {
+    const child = Fluent(c as HTMLElement)
+    const childName = (child.attr('id') ?? '').replace(prefix, '')
+    if (childName && !columns.includes(childName) && !child.hasClass('group-member')) {
+      child.style(css => {
+        css.height = `${height * 2 - 2}px`
+        css.display = 'flex'
+        css.alignItems = 'center'
+      })
+      if (childName !== `${columnName}Group`) {
+        child.findFirst('.slick-column-name')?.style(css => {
+          css.whiteSpace = 'normal'
+        })
+      }
+    } else {
+      child.findFirst('.slick-resizable-handle')?.remove()
+      if (childName !== columnName) {
+        document.querySelector(`#${prefix}${childName}`)?.addEventListener('click', (evt: Event) => {
+          evt.preventDefault()
+          evt.stopPropagation()
+          return false
+        })
+      }
+      child
+        .style(css => {
+          css.left = '0'
+          css.borderBottom = 'none'
+          css.height = `${height - 1}px`
+        })
+        .addClass(['group-member'])
+        .appendTo(groupPanel)
+    }
+  })
+}
+
+export function groupHeaderColumns(
+  domNode: HTMLElement,
+  title: string,
+  columnName: string,
+  columnCount: number,
+  height: number,
+): void {
+  // The standalone variant follows the same logic as the (formerly prototype)
+  // groupColumnHeader; the original source kept both. Delegating for consistency.
+  groupColumnHeader(domNode, title, columnName, columnCount, height)
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Async DOM-ready helpers
+// ──────────────────────────────────────────────────────────────────────────
+
+/**
+ * Resolve when the first SlickGrid header-column element is measurable.
+ * Internally polls via getTargetElement → getElementHeight.
+ */
+export function getColumnHeaderHeight(domNode: HTMLElement): Promise<number> {
+  return getTargetElement(domNode, 'slick-header')
+    .then(header => getTargetElement(header, 'slick-header-columns'))
+    .then(headerColumns => getTargetElement(headerColumns, 'slick-header-column'))
+    .then(headerColumn => getElementHeight(headerColumn))
+}
+
+/**
+ * Resolve with the first ClientRect height of `element` after a 500ms delay.
+ * Rejects if the rect is unavailable.
+ */
+export function getElementHeight(element: HTMLElement): Promise<number> {
+  return new Promise<number>((resolve, reject) => {
+    setTimeout(() => {
+      const rect = element.getClientRects().item(0)
+      if (rect && rect.height) resolve(rect.height)
+      else reject(new Error('Element height not found.'))
+    }, 500)
+  })
+}
+
+/**
+ * Resolve with the first descendant of `container` matching `.${cssClass}`
+ * after a 100ms delay. Rejects if not found.
+ */
+export function getTargetElement(container: HTMLElement, cssClass: string): Promise<HTMLElement> {
+  return new Promise<HTMLElement>((resolve, reject) => {
+    setTimeout(() => {
+      const target = container.querySelector<HTMLElement>(`.${cssClass}`)
+      if (target) resolve(target)
+      else reject(new Error(`Element with selector ".${cssClass}" not found within the specified domNode.`))
+    }, 100)
+  })
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// DOM construction shorthand
+// ──────────────────────────────────────────────────────────────────────────
+
+export function createDivWithClassesAndAppendBefore(
+  domNode: HTMLElement,
+  selector: string,
+  classes: string,
+): void {
+  const div = document.createElement('div')
+  div.classList.add(...classes.split(' ').filter(Boolean))
+  const existing = domNode.querySelector(selector)
+  if (existing?.parentNode) existing.parentNode.insertBefore(div, existing)
+}
+
+export function createDivWithClassesAndAppendAfter(
+  domNode: HTMLElement,
+  selector: string,
+  classes: string,
+): void {
+  const div = document.createElement('div')
+  div.classList.add(...classes.split(' ').filter(Boolean))
+  const existing = domNode.querySelector(selector)
+  existing?.parentNode?.insertBefore(div, existing.nextSibling)
+}
+
+export function createDivWithClassesAndAppendTo(
+  domNode: HTMLElement,
+  selector: string,
+  classes: string,
+): void {
+  const div = document.createElement('div')
+  div.classList.add(...classes.split(' ').filter(Boolean))
+  domNode.querySelector(selector)?.appendChild(div)
+}
+
+export function moveDivToNewParent(
+  domNode: HTMLElement,
+  newParentSelector: string,
+  targetChildSelector: string,
+): void {
+  const newParent = domNode.querySelector(newParentSelector)
+  const targetChild = domNode.querySelector(targetChildSelector)
+  if (newParent && targetChild) newParent.appendChild(targetChild)
+}
+
+export function moveDivsToNewParent(
+  domNode: HTMLElement,
+  newParentSelector: string,
+  targetChildSelector: string,
+): void {
+  const newParent = domNode.querySelector(newParentSelector)
+  if (!newParent) return
+  const targetChildren = domNode.querySelectorAll(targetChildSelector)
+  targetChildren.forEach(child => newParent.appendChild(child))
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Form-field caption layout helpers
+// ──────────────────────────────────────────────────────────────────────────
+
+export function labelCaptionTopLeft(field: string, captionClass: string): void {
+  applyCSS([field], { flexWrap: 'wrap' })
+  applyCSS([captionClass], {
+    width: '150px',
+    marginBottom: '2px',
+    textAlign: 'left',
+    flexBasis: '100%',
+  })
+}
+
+export function labelCaptionTopRight(field: string, captionClass: string): void {
+  applyCSS([field], { flexWrap: 'wrap' })
+  applyCSS([captionClass], {
+    width: '150px',
+    marginBottom: '2px',
+    textAlign: 'right',
+    flexBasis: '100%',
+  })
+}
+
+/**
+ * Apply a CSS property map to every element matching each selector. Silent
+ * no-op when a selector matches nothing (the source logged Thai-language
+ * errors; replaced with silent fail per project no-console policy).
+ */
+export function applyCSS(selectors: string[], properties: Record<string, string>): void {
+  for (const selector of selectors) {
+    const elements = document.querySelectorAll(selector)
+    elements.forEach(el => {
+      if (el instanceof HTMLElement) {
+        for (const property of Object.keys(properties)) {
+          // Mutating via index signature for camelCase CSS properties (the
+          // browser accepts both kebab- and camelCase). Cast keeps TS happy.
+          ;(el.style as unknown as Record<string, string>)[property] = properties[property]
+        }
+      }
+    })
+  }
+}
+
+export function addCssClassToField(
+  domNode: HTMLElement,
+  fields: string[],
+  ...cssClass: string[]
+): void {
+  for (const field of fields) {
+    domNode.querySelectorAll(`.field.${field}`).forEach(el => {
+      if (el instanceof HTMLElement) el.classList.add(...cssClass)
+    })
+  }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Toolbar button state
+// ──────────────────────────────────────────────────────────────────────────
+
+export function toggleButtonInForm(
+  domNode: HTMLElement,
+  className: string,
+  shouldEnable: boolean,
+): void {
+  const button = domNode.querySelector<HTMLButtonElement>(`.${className}`)
+  if (!button) return
+  button.classList.toggle('disabled', !shouldEnable)
+  button.disabled = !shouldEnable
+}
+
+export function toggleButton(toolbar: Toolbar, buttonName: string, shouldEnable: boolean): void {
+  toolbar.findButton(buttonName).toggleClass('disabled', !shouldEnable)
+}

--- a/src/helpers/layoutHelper.ts
+++ b/src/helpers/layoutHelper.ts
@@ -9,8 +9,9 @@ import { Fluent, Toolbar } from '@serenity-is/corelib'
  *   // PowerACC:
  *   element.createLayout(3, 'col')
  *
- *   // idevs.corelib:
- *   import { createLayout } from '@idevs/corelib/helpers'
+ *   // idevs.corelib (helpers are re-exported from the root barrel; there is
+ *   // no separate '@idevs/corelib/helpers' subpath in package.json#exports):
+ *   import { createLayout } from '@idevs/corelib'
  *   createLayout(element, 3, 'col')
  *
  * Behavioral parity is preserved otherwise.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,8 @@
 // Core modules
 export * from './editors'
+export * from './dialogs'
 export * from './formatters'
+export * from './panels'
 export * from './ui'
 export * from './helpers'
 

--- a/src/panels/idevsOffcanvasPanel.ts
+++ b/src/panels/idevsOffcanvasPanel.ts
@@ -1,4 +1,10 @@
-import { Decorators, type EntityDialog, Widget, type WidgetProps } from '@serenity-is/corelib'
+import {
+  Decorators,
+  type EntityDialog,
+  notifyError,
+  Widget,
+  type WidgetProps,
+} from '@serenity-is/corelib'
 
 /**
  * Bootstrap offcanvas slide-out panel that hosts an EntityDialog. The dialog
@@ -112,11 +118,24 @@ export class IdevsOffcanvasPanel extends Widget<IdevsOffcanvasPanelOptions> {
     // Explicit nullish check — `if (id)` would skip valid falsy ids like 0
     // or '' (numeric 0 is a legitimate primary key in many systems).
     if (id !== undefined && id !== null) {
-      // The source passes two no-op callbacks for success/error — preserve.
       this.dlg.loadById(
         id as never,
-        () => {},
-        () => {},
+        () => {
+          // Success: no-op (the dialog will render its loaded entity).
+        },
+        () => {
+          // Source's port passed `() => {}` for error — preserving that
+          // hid every load failure (404 / 500 / deleted record / auth)
+          // and left users staring at a blank offcanvas. Surface a
+          // user-visible error and tear down so the panel doesn't get
+          // stuck half-open. Serenity's typed signature is `() => void`
+          // (no payload); the dialog framework surfaces its own toast
+          // for the underlying service error — this notification
+          // confirms to the user that the offcanvas close was a
+          // consequence, not a freeze.
+          notifyError('Failed to load record.')
+          this.teardown()
+        },
       )
     }
 

--- a/src/panels/idevsOffcanvasPanel.ts
+++ b/src/panels/idevsOffcanvasPanel.ts
@@ -1,0 +1,190 @@
+import { Decorators, type EntityDialog, Widget, type WidgetProps } from '@serenity-is/corelib'
+
+/**
+ * Bootstrap offcanvas slide-out panel that hosts an EntityDialog. The dialog
+ * is initialized lazily via `props.initDialog()`; on `load()` it opens
+ * inside the offcanvas body. `onDataChangeCallback` fires when the embedded
+ * dialog emits an `ondatachange` event, and the panel destroys itself.
+ *
+ * Replaces PowerACC's `OffCanvasPanel`. Hardening:
+ *   - Source had three debug `console.log/error` calls; removed.
+ *   - `target.parentElement.parentElement` chains null-guarded.
+ *   - title `innerHTML` copy from the dialog titlebar replaced with a
+ *     textContent + cloneNode round-trip (preserves child markup safely
+ *     when the consumer rendered the titlebar via DOM API).
+ *   - generateRandomId from PowerACC inlined as a Math.random base36
+ *     substring (8 chars) — matches the source's id-length expectation.
+ *   - `injectDialogIntoPanel` retry-limit of 100 (10s total) preserved
+ *     from source; the silent give-up replaces the source's console.error.
+ */
+
+export type IdevsOffcanvasPanelOptions = {
+  target: HTMLElement
+  initDialog: () => EntityDialog<unknown, unknown>
+  onDataChangeCallback?: () => void
+  sliderWidth?: string | number
+  entityOrId?: string | number | Record<string, unknown>
+}
+
+function generateRandomId(length: number): string {
+  return Math.random().toString(36).substring(2, 2 + length)
+}
+
+@Decorators.registerClass('Idevs.CoreLib.IdevsOffcanvasPanel')
+export class IdevsOffcanvasPanel extends Widget<IdevsOffcanvasPanelOptions> {
+  private readonly canvasId: string
+  private overlayDiv!: HTMLElement
+  private readonly dlg: EntityDialog<unknown, unknown>
+
+  constructor(prop: WidgetProps<IdevsOffcanvasPanelOptions>) {
+    super(prop)
+
+    const target = this.getTargetElement()
+    this.dlg = this.props.initDialog()
+    this.canvasId = generateRandomId(8)
+    this.createCanvasElement()
+    target.appendChild(this.domNode)
+
+    // The embedded dialog signals data changes via jQuery custom event.
+    // We listen, invoke the consumer's callback, and tear down.
+    $(this.dlg.domNode).on('ondatachange', () => {
+      this.props.onDataChangeCallback?.()
+      this.domNode.remove()
+    })
+  }
+
+  public load(id?: string | number): void {
+    if (id) {
+      // The source passes two no-op callbacks for success/error — preserve.
+      this.dlg.loadById(
+        id as never,
+        () => {},
+        () => {},
+      )
+    }
+
+    document.body.classList.add('with-offcanvas-panel')
+
+    const body = this.overlayDiv.querySelector('.offcanvas-body')
+    if (!body) return
+
+    this.dlg.dialogOpen(true)
+    const parent = this.dlg.domNode.parentElement
+    if (parent) {
+      parent.classList.add('offcanvas-item')
+      body.appendChild(parent)
+    }
+
+    this.injectDialogIntoPanel()
+  }
+
+  private createCanvasElement(): void {
+    const btnToggle = document.createElement('button')
+    btnToggle.setAttribute('id', `canvasToggle_${this.canvasId}`)
+    btnToggle.classList.add('d-none')
+    btnToggle.setAttribute('type', 'button')
+    btnToggle.setAttribute('data-bs-toggle', 'offcanvas')
+    btnToggle.setAttribute('data-bs-target', `#offcanvasRight_${this.canvasId}`)
+    btnToggle.setAttribute('aria-controls', `offcanvasRight_${this.canvasId}`)
+    this.domNode.append(btnToggle)
+
+    this.overlayDiv = document.createElement('div')
+    this.overlayDiv.classList.add('offcanvas', 'offcanvas-end')
+    this.overlayDiv.setAttribute('tabindex', '-1')
+    this.overlayDiv.setAttribute('id', `offcanvasRight_${this.canvasId}`)
+    this.overlayDiv.setAttribute('aria-labelledby', `offcanvasRightLabel_${this.canvasId}`)
+    this.overlayDiv.setAttribute('role', 'dialog')
+    this.overlayDiv.setAttribute('aria-modal', 'true')
+
+    const header = document.createElement('div')
+    header.classList.add('offcanvas-header')
+
+    const title = document.createElement('h5')
+    title.classList.add('offcanvas-title')
+    title.setAttribute('id', `offcanvasRightLabel_${this.canvasId}`)
+
+    const closeButton = document.createElement('button')
+    closeButton.classList.add('btn-close')
+    closeButton.setAttribute('type', 'button')
+    closeButton.setAttribute('data-bs-dismiss', 'offcanvas')
+    closeButton.setAttribute('aria-label', 'Close')
+
+    header.appendChild(title)
+    header.appendChild(closeButton)
+    this.overlayDiv.appendChild(header)
+
+    const body = document.createElement('div')
+    body.classList.add('offcanvas-body')
+
+    this.overlayDiv.appendChild(body)
+    this.domNode.append(this.overlayDiv)
+  }
+
+  private getTargetElement(): HTMLElement {
+    const target = this.props.target
+    if (target.classList.contains('panel-body')) {
+      return target.parentElement?.parentElement ?? target
+    }
+    if (target.classList.contains('ui-dialog-content')) {
+      return target.parentElement ?? target
+    }
+    return target
+  }
+
+  private injectDialogIntoPanel(): void {
+    const MAX_RETRIES = 100
+    let attempts = 0
+
+    const tryInject = (): void => {
+      setTimeout(() => {
+        attempts++
+        if (attempts >= MAX_RETRIES) return // give up silently (source console.error'd)
+
+        if (!this.overlayDiv.querySelector('.panel-titlebar')) {
+          tryInject()
+          return
+        }
+
+        // Unhide any previously-hidden sibling panel.
+        let parent: HTMLElement | null = this.overlayDiv.parentElement
+        if (parent?.getAttribute('data-hiddenby')) {
+          const lastChild = parent.parentElement?.querySelector<HTMLElement>(
+            '.s-Panel[data-hiddenby]:not(.offcanvas-item)',
+          )
+          lastChild?.removeAttribute('data-hiddenby')
+          parent.removeAttribute('data-hiddenby')
+        } else {
+          parent = this.getTargetElement()
+          parent.removeAttribute('data-hiddenby')
+        }
+
+        setTimeout(() => {
+          const titlebar = this.overlayDiv.querySelector<HTMLElement>('.panel-titlebar')
+          const titleEl = this.overlayDiv.querySelector<HTMLElement>('.offcanvas-title')
+          if (titlebar && titleEl) {
+            // XSS-safer than innerHTML copy — clone the first child node tree
+            // into the title element. textContent fallback when there's no
+            // child element.
+            const firstChild = titlebar.firstElementChild
+            if (firstChild) {
+              titleEl.replaceChildren(firstChild.cloneNode(true))
+            } else {
+              titleEl.textContent = titlebar.textContent ?? ''
+            }
+            titlebar.remove()
+          }
+        }, 100)
+
+        const dialogParent = this.dlg.domNode.parentElement
+        if (dialogParent) dialogParent.style.setProperty('display', 'block', 'important')
+
+        const btn = this.domNode.querySelector<HTMLButtonElement>(
+          `#canvasToggle_${this.canvasId}`,
+        )
+        btn?.click()
+      }, 100)
+    }
+
+    tryInject()
+  }
+}

--- a/src/panels/idevsOffcanvasPanel.ts
+++ b/src/panels/idevsOffcanvasPanel.ts
@@ -22,8 +22,11 @@ export type IdevsOffcanvasPanelOptions = {
   target: HTMLElement
   initDialog: () => EntityDialog<unknown, unknown>
   onDataChangeCallback?: () => void
-  sliderWidth?: string | number
-  entityOrId?: string | number | Record<string, unknown>
+  // NOTE: PowerACC's source declared `sliderWidth` and `entityOrId` on the
+  // options type but never read either. Dropped here to avoid a misleading
+  // API surface. Consumers needing custom panel width should set it via
+  // CSS or extend this class; consumers wanting auto-load by id can pass
+  // it to `load(id)` directly.
 }
 
 function generateRandomId(length: number): string {
@@ -32,9 +35,13 @@ function generateRandomId(length: number): string {
 
 @Decorators.registerClass('Idevs.CoreLib.IdevsOffcanvasPanel')
 export class IdevsOffcanvasPanel extends Widget<IdevsOffcanvasPanelOptions> {
+  private static readonly BODY_OPEN_CLASS = 'with-offcanvas-panel'
+
   private readonly canvasId: string
   private overlayDiv!: HTMLElement
   private readonly dlg: EntityDialog<unknown, unknown>
+  private isLoaded = false
+  private isTorn = false
 
   constructor(prop: WidgetProps<IdevsOffcanvasPanelOptions>) {
     super(prop)
@@ -46,11 +53,42 @@ export class IdevsOffcanvasPanel extends Widget<IdevsOffcanvasPanelOptions> {
     target.appendChild(this.domNode)
 
     // The embedded dialog signals data changes via jQuery custom event.
-    // We listen, invoke the consumer's callback, and tear down.
-    $(this.dlg.domNode).on('ondatachange', () => {
+    // Both event spellings supported (IdevsEntityDialog dispatches both
+    // 'onDataChange' and 'ondatachange' — see batch 4a Copilot review).
+    const handler = () => {
       this.props.onDataChangeCallback?.()
-      this.domNode.remove()
-    })
+      this.teardown()
+    }
+    $(this.dlg.domNode).on('onDataChange ondatachange', handler)
+  }
+
+  override destroy(): void {
+    this.teardown()
+    super.destroy()
+  }
+
+  /**
+   * Idempotent teardown — removes the body class, detaches the jQuery
+   * data-change listener, destroys the embedded dialog, and removes the
+   * panel's DOM. Used by both the dialog's data-change event and the
+   * Widget destroy() override.
+   */
+  private teardown(): void {
+    if (this.isTorn) return
+    this.isTorn = true
+
+    document.body.classList.remove(IdevsOffcanvasPanel.BODY_OPEN_CLASS)
+    try {
+      $(this.dlg.domNode).off('onDataChange ondatachange')
+    } catch {
+      /* dialog DOM may already be detached */
+    }
+    try {
+      this.dlg.destroy()
+    } catch {
+      /* dialog destroy can throw if Serenity's chain races; swallow */
+    }
+    this.domNode.remove()
   }
 
   public load(id?: string | number): void {
@@ -63,7 +101,19 @@ export class IdevsOffcanvasPanel extends Widget<IdevsOffcanvasPanelOptions> {
       )
     }
 
-    document.body.classList.add('with-offcanvas-panel')
+    document.body.classList.add(IdevsOffcanvasPanel.BODY_OPEN_CLASS)
+    this.isLoaded = true
+
+    // Hook into Bootstrap's offcanvas hidden event (fires on Esc, backdrop
+    // click, or close-button click) to drop the body class. Without this
+    // the `with-offcanvas-panel` style would persist after dismissal.
+    this.overlayDiv.addEventListener(
+      'hidden.bs.offcanvas',
+      () => {
+        document.body.classList.remove(IdevsOffcanvasPanel.BODY_OPEN_CLASS)
+      },
+      { once: true },
+    )
 
     const body = this.overlayDiv.querySelector('.offcanvas-body')
     if (!body) return

--- a/src/panels/idevsOffcanvasPanel.ts
+++ b/src/panels/idevsOffcanvasPanel.ts
@@ -124,12 +124,16 @@ export class IdevsOffcanvasPanel extends Widget<IdevsOffcanvasPanelOptions> {
     this.isLoaded = true
 
     // Hook into Bootstrap's offcanvas hidden event (fires on Esc, backdrop
-    // click, or close-button click) to drop the body class. Without this
-    // the `with-offcanvas-panel` style would persist after dismissal.
+    // click, or close-button click) and route through full teardown.
+    // Previously this handler only removed the body class — the embedded
+    // dialog, jQuery data-change listener, and pending injectDialogIntoPanel
+    // timers would all leak when the user dismissed via any of those
+    // non-data-change paths. teardown() is idempotent so the followup
+    // ondatachange path (when present) is harmless.
     this.overlayDiv.addEventListener(
       'hidden.bs.offcanvas',
       () => {
-        document.body.classList.remove(IdevsOffcanvasPanel.BODY_OPEN_CLASS)
+        this.teardown()
       },
       { once: true },
     )

--- a/src/panels/idevsOffcanvasPanel.ts
+++ b/src/panels/idevsOffcanvasPanel.ts
@@ -109,7 +109,9 @@ export class IdevsOffcanvasPanel extends Widget<IdevsOffcanvasPanelOptions> {
   }
 
   public load(id?: string | number): void {
-    if (id) {
+    // Explicit nullish check — `if (id)` would skip valid falsy ids like 0
+    // or '' (numeric 0 is a legitimate primary key in many systems).
+    if (id !== undefined && id !== null) {
       // The source passes two no-op callbacks for success/error — preserve.
       this.dlg.loadById(
         id as never,

--- a/src/panels/idevsOffcanvasPanel.ts
+++ b/src/panels/idevsOffcanvasPanel.ts
@@ -69,9 +69,38 @@ export class IdevsOffcanvasPanel extends Widget<IdevsOffcanvasPanelOptions> {
     // those events, including ones the consumer may have attached).
     this.dataChangeHandler = () => {
       this.props.onDataChangeCallback?.()
-      this.teardown()
+      this.hideThenTeardown()
     }
     $(this.dlg.domNode).on('onDataChange ondatachange', this.dataChangeHandler)
+  }
+
+  /**
+   * If the offcanvas is currently shown by Bootstrap, ask Bootstrap to
+   * hide it first — its hide.bs.offcanvas/hidden.bs.offcanvas lifecycle
+   * tears down the backdrop, releases focus, and unlocks body scroll.
+   * Calling teardown() directly removes the DOM but leaves all three of
+   * those states stuck active. The hidden.bs.offcanvas listener wired in
+   * load() will then call teardown() after Bootstrap finishes hiding.
+   *
+   * Fallback: if no Bootstrap Offcanvas instance is bound (rare —
+   * happens if the consumer manually disposed it), teardown directly.
+   */
+  private hideThenTeardown(): void {
+    const Offcanvas = (
+      window as unknown as {
+        bootstrap?: {
+          Offcanvas?: { getInstance(el: HTMLElement): { hide(): void } | null }
+        }
+      }
+    ).bootstrap?.Offcanvas
+    const instance = Offcanvas?.getInstance(this.overlayDiv) ?? null
+    if (instance) {
+      // hidden.bs.offcanvas (once-only handler registered in load) will
+      // call teardown() after the fade-out animation completes.
+      instance.hide()
+    } else {
+      this.teardown()
+    }
   }
 
   override destroy(): void {

--- a/src/panels/idevsOffcanvasPanel.ts
+++ b/src/panels/idevsOffcanvasPanel.ts
@@ -42,6 +42,9 @@ export class IdevsOffcanvasPanel extends Widget<IdevsOffcanvasPanelOptions> {
   private readonly dlg: EntityDialog<unknown, unknown>
   private isLoaded = false
   private isTorn = false
+  private dataChangeHandler?: () => void
+  /** Pending setTimeout handles from injectDialogIntoPanel's retry loop. */
+  private pendingTimers: Array<ReturnType<typeof setTimeout>> = []
 
   constructor(prop: WidgetProps<IdevsOffcanvasPanelOptions>) {
     super(prop)
@@ -55,11 +58,14 @@ export class IdevsOffcanvasPanel extends Widget<IdevsOffcanvasPanelOptions> {
     // The embedded dialog signals data changes via jQuery custom event.
     // Both event spellings supported (IdevsEntityDialog dispatches both
     // 'onDataChange' and 'ondatachange' — see batch 4a Copilot review).
-    const handler = () => {
+    // Handler stored on the instance so teardown can call .off() with the
+    // function reference (otherwise .off() would remove ALL listeners for
+    // those events, including ones the consumer may have attached).
+    this.dataChangeHandler = () => {
       this.props.onDataChangeCallback?.()
       this.teardown()
     }
-    $(this.dlg.domNode).on('onDataChange ondatachange', handler)
+    $(this.dlg.domNode).on('onDataChange ondatachange', this.dataChangeHandler)
   }
 
   override destroy(): void {
@@ -78,10 +84,21 @@ export class IdevsOffcanvasPanel extends Widget<IdevsOffcanvasPanelOptions> {
     this.isTorn = true
 
     document.body.classList.remove(IdevsOffcanvasPanel.BODY_OPEN_CLASS)
-    try {
-      $(this.dlg.domNode).off('onDataChange ondatachange')
-    } catch {
-      /* dialog DOM may already be detached */
+
+    // Cancel any pending injectDialogIntoPanel retries so they can't run
+    // against detached DOM (or click the hidden toggle button) after teardown.
+    for (const id of this.pendingTimers) clearTimeout(id)
+    this.pendingTimers = []
+
+    if (this.dataChangeHandler) {
+      try {
+        // Scoped removal — pass the handler reference so we don't strip
+        // listeners that consumers attached for the same event names.
+        $(this.dlg.domNode).off('onDataChange ondatachange', this.dataChangeHandler)
+      } catch {
+        /* dialog DOM may already be detached */
+      }
+      this.dataChangeHandler = undefined
     }
     try {
       this.dlg.destroy()
@@ -185,8 +202,20 @@ export class IdevsOffcanvasPanel extends Widget<IdevsOffcanvasPanelOptions> {
     const MAX_RETRIES = 100
     let attempts = 0
 
+    const scheduleTimer = (cb: () => void, delay: number): void => {
+      if (this.isTorn) return
+      const id = setTimeout(() => {
+        // Drop the handle from the pending list before running the callback
+        // so destroy() doesn't try to clear an already-fired timer.
+        this.pendingTimers = this.pendingTimers.filter(t => t !== id)
+        if (this.isTorn) return
+        cb()
+      }, delay)
+      this.pendingTimers.push(id)
+    }
+
     const tryInject = (): void => {
-      setTimeout(() => {
+      scheduleTimer(() => {
         attempts++
         if (attempts >= MAX_RETRIES) return // give up silently (source console.error'd)
 
@@ -208,13 +237,13 @@ export class IdevsOffcanvasPanel extends Widget<IdevsOffcanvasPanelOptions> {
           parent.removeAttribute('data-hiddenby')
         }
 
-        setTimeout(() => {
+        scheduleTimer(() => {
           const titlebar = this.overlayDiv.querySelector<HTMLElement>('.panel-titlebar')
           const titleEl = this.overlayDiv.querySelector<HTMLElement>('.offcanvas-title')
           if (titlebar && titleEl) {
-            // XSS-safer than innerHTML copy — clone the first child node tree
-            // into the title element. textContent fallback when there's no
-            // child element.
+            // XSS-safer than raw markup copy — clone the first child node
+            // tree into the title element. textContent fallback when
+            // there's no child element.
             const firstChild = titlebar.firstElementChild
             if (firstChild) {
               titleEl.replaceChildren(firstChild.cloneNode(true))

--- a/src/panels/idevsPage.ts
+++ b/src/panels/idevsPage.ts
@@ -1,0 +1,80 @@
+import {
+  Decorators,
+  Fluent,
+  Toolbar,
+  type ToolButton,
+  Widget,
+  type WidgetProps,
+} from '@serenity-is/corelib'
+
+/**
+ * Page-level container — title bar + toolbar + content pane in a vertical
+ * flex layout. Replaces PowerACC's `CsiPage`.
+ *
+ * Hardening vs source:
+ *   - Source used preact `render(<CsiTitle title={...}/>)` to render the
+ *     title element. Dropped the preact dependency in favor of plain
+ *     textContent — same visual outcome, no JSX runtime needed in corelib.
+ */
+
+export type IdevsPageOptions = Record<string, never>
+
+@Decorators.registerClass('Idevs.CoreLib.IdevsPage')
+export class IdevsPage<P extends IdevsPageOptions = IdevsPageOptions> extends Widget<P> {
+  protected toolbar!: Toolbar
+  protected panelContainer!: Fluent
+
+  constructor(props: WidgetProps<P>) {
+    super(props)
+    this.render()
+  }
+
+  override render(): unknown {
+    return super.render()
+  }
+
+  internalRenderContents(): void {
+    this.element.addClass(['flex-fill', 'd-flex', 'flex-column'])
+
+    const titleDiv = Fluent('div').class(['panel-titlebar']).appendTo(this.element)
+    this.renderTitle(titleDiv.getNode())
+
+    this.toolbar = new Toolbar({ buttons: this.getButtons() })
+    const toolbarDiv = Fluent('div')
+      .class(['s-Toolbar', 'clearfix'])
+      .appendTo(this.element)
+    this.getButtons().forEach(button => {
+      this.toolbar.createButton(toolbarDiv.getNode(), button)
+    })
+    this.toolbar.render()
+
+    this.panelContainer = Fluent('div')
+      .class(['panel-container', 'position-relative', 'flex-fill'])
+      .appendTo(this.element)
+
+    super.internalRenderContents()
+  }
+
+  protected override renderContents(): unknown {
+    return super.renderContents()
+  }
+
+  protected getButtons(): ToolButton[] {
+    return []
+  }
+
+  protected getTitle(): string {
+    return 'Idevs Page'
+  }
+
+  /**
+   * Render the title bar. Plain DOM (no preact dependency). Subclasses can
+   * override for custom title markup.
+   */
+  protected renderTitle(element: HTMLElement): void {
+    const titleSpan = document.createElement('div')
+    titleSpan.classList.add('title-text')
+    titleSpan.textContent = this.getTitle()
+    element.appendChild(titleSpan)
+  }
+}

--- a/src/panels/idevsPage.ts
+++ b/src/panels/idevsPage.ts
@@ -39,18 +39,25 @@ export class IdevsPage<P extends IdevsPageOptions = IdevsPageOptions> extends Wi
     const titleDiv = Fluent('div').class(['panel-titlebar']).appendTo(this.element)
     this.renderTitle(titleDiv.getNode())
 
+    // Single toolbar surface: construct Toolbar bound to the visible
+    // toolbarDiv so `this.toolbar.findButton()` / `updateInterface()` /
+    // `destroy()` operate on the buttons users actually see. Previously
+    // we built a detached Toolbar instance AND manually re-rendered the
+    // buttons into a separate div — the Toolbar instance's internal
+    // domNode was orphaned, so subclass code calling
+    // `this.toolbar.findButton(...)` would search a hidden tree and
+    // return nothing.
+    const toolbarDiv = Fluent('div')
+      .class(['s-Toolbar', 'clearfix'])
+      .appendTo(this.element)
     // Cache getButtons() — without this, an override that returns a fresh
     // array (or has side effects) would render a different set than the
     // toolbar was constructed with.
     const buttons = this.getButtons()
-    this.toolbar = new Toolbar({ buttons })
-    const toolbarDiv = Fluent('div')
-      .class(['s-Toolbar', 'clearfix'])
-      .appendTo(this.element)
-    buttons.forEach(button => {
-      this.toolbar.createButton(toolbarDiv.getNode(), button)
+    this.toolbar = new Toolbar({
+      element: toolbarDiv.getNode(),
+      buttons,
     })
-    this.toolbar.render()
 
     this.panelContainer = Fluent('div')
       .class(['panel-container', 'position-relative', 'flex-fill'])

--- a/src/panels/idevsPage.ts
+++ b/src/panels/idevsPage.ts
@@ -39,11 +39,15 @@ export class IdevsPage<P extends IdevsPageOptions = IdevsPageOptions> extends Wi
     const titleDiv = Fluent('div').class(['panel-titlebar']).appendTo(this.element)
     this.renderTitle(titleDiv.getNode())
 
-    this.toolbar = new Toolbar({ buttons: this.getButtons() })
+    // Cache getButtons() — without this, an override that returns a fresh
+    // array (or has side effects) would render a different set than the
+    // toolbar was constructed with.
+    const buttons = this.getButtons()
+    this.toolbar = new Toolbar({ buttons })
     const toolbarDiv = Fluent('div')
       .class(['s-Toolbar', 'clearfix'])
       .appendTo(this.element)
-    this.getButtons().forEach(button => {
+    buttons.forEach(button => {
       this.toolbar.createButton(toolbarDiv.getNode(), button)
     })
     this.toolbar.render()

--- a/src/panels/idevsPanel.ts
+++ b/src/panels/idevsPanel.ts
@@ -159,6 +159,11 @@ export class IdevsPanel<P extends IdevsPanelOptions = IdevsPanelOptions> extends
 
   /** Render the registered fields into the panel container. */
   protected async renderPanel(): Promise<Fluent> {
+    // Destroy any editor instances from a prior render before emptying the
+    // DOM — otherwise we'd orphan their event handlers and any internal
+    // state, AND a stale getEditor() / setFieldValue() call could still
+    // mutate the dead editor. Reset the registry too.
+    this.destroyEditorInstances()
     this.panelContainer.empty()
     this.fields.forEach(field => {
       field.container = this.panelContainer
@@ -166,6 +171,27 @@ export class IdevsPanel<P extends IdevsPanelOptions = IdevsPanelOptions> extends
       this.instantiateEditor(field)
     })
     return this.panelContainer
+  }
+
+  private destroyEditorInstances(): void {
+    for (const key of Object.keys(this.editorInstances)) {
+      try {
+        this.editorInstances[key].destroy()
+      } catch {
+        /* swallow teardown errors */
+      }
+    }
+    this.editorInstances = {}
+    // Also clear the editorInstance back-reference on each field so dead
+    // pointers aren't held in user-owned field configs.
+    this.fields.forEach(f => {
+      f.editorInstance = undefined
+    })
+  }
+
+  override destroy(): void {
+    this.destroyEditorInstances()
+    super.destroy()
   }
 
   private addFieldToContainer(field: IdevsPanelFieldOptions): Fluent {

--- a/src/panels/idevsPanel.ts
+++ b/src/panels/idevsPanel.ts
@@ -67,6 +67,8 @@ export class IdevsPanel<P extends IdevsPanelOptions = IdevsPanelOptions> extends
   protected fields: IdevsPanelFieldOptions[] = []
   private dummyFields = 0
   protected panelContainer!: Fluent
+  /** Floating title element — reference held so setTitle can update it. */
+  private floatingTitleEl?: HTMLElement
   protected editorInstances: Record<string, Widget<unknown>> = {}
 
   static createPanel<P extends IdevsPanelOptions = IdevsPanelOptions>(
@@ -109,13 +111,37 @@ export class IdevsPanel<P extends IdevsPanelOptions = IdevsPanelOptions> extends
   }
   setTitle(value: string): void {
     this.panelTitle = value
+    // Update the rendered floating title too — without this the visible
+    // text would never refresh after construction. The element is created
+    // via the deferred createFloatingTitle setTimeout(0); if setTitle is
+    // called BEFORE that fires, the deferred render reads the latest
+    // panelTitle value naturally.
+    if (this.floatingTitleEl) this.floatingTitleEl.textContent = value
   }
 
   getFields(): IdevsPanelFieldOptions[] {
     return this.fields
   }
+  /**
+   * Set the field list and re-render. Called as the public replacement
+   * for the old PowerACC `Fields = [...]` setter; consumers expect the
+   * new field list to materialize without further action.
+   */
   setFields(value: IdevsPanelFieldOptions[]): void {
     this.fields = value
+    // Fire-and-forget — renderPanel returns a Promise<Fluent> but the
+    // current implementation is synchronous. The promise interface exists
+    // for future async hooks.
+    if (this.panelContainer) void this.renderPanel()
+  }
+
+  /**
+   * Public render entry point — re-renders the panel with the current
+   * field list. Consumers needing to refresh the panel after mutating
+   * `getFields()` directly can call this.
+   */
+  public render(): Promise<Fluent> {
+    return this.renderPanel()
   }
 
   constructor(props: WidgetProps<P>) {
@@ -145,7 +171,7 @@ export class IdevsPanel<P extends IdevsPanelOptions = IdevsPanelOptions> extends
   /** Overlays the panel title as a floating label on the top border. */
   private createFloatingTitle(wrapper: Fluent): void {
     setTimeout(() => {
-      Fluent('div')
+      const titleEl = Fluent('div')
         .class(['position-absolute', 'px-3'])
         .style(css => {
           css.left = '1rem'
@@ -154,6 +180,9 @@ export class IdevsPanel<P extends IdevsPanelOptions = IdevsPanelOptions> extends
         })
         .text(this.panelTitle)
         .appendTo(wrapper)
+        .getNode()
+      // Cache the element so setTitle can update its text after creation.
+      this.floatingTitleEl = titleEl as HTMLElement
     }, 0)
   }
 

--- a/src/panels/idevsPanel.ts
+++ b/src/panels/idevsPanel.ts
@@ -88,10 +88,14 @@ export class IdevsPanel<P extends IdevsPanelOptions = IdevsPanelOptions> extends
   }
 
   static override createDefaultElement(): HTMLElement {
+    // CSS class matches the widget identity (s-IdevsPanel). The PowerACC
+    // source used 's-CsiFilterPanel' here even though the class was
+    // CsiPanel — a naming mismatch that would have broken selector-based
+    // lookups against an s-IdevsPanel-style stylesheet.
     return Fluent('div')
       .class([
-        'idevs-filter-panel',
-        's-IdevsFilterPanel',
+        'idevs-panel',
+        's-IdevsPanel',
         'w-100',
         'd-flex',
         'flex-column',
@@ -133,7 +137,7 @@ export class IdevsPanel<P extends IdevsPanelOptions = IdevsPanelOptions> extends
       ])
       .appendTo(container)
     this.panelContainer = Fluent('div')
-      .class(['idevs-filter-criteria-panel', 'flex-fill', 'd-flex', 'flex-wrap'])
+      .class(['idevs-panel-criteria', 'flex-fill', 'd-flex', 'flex-wrap'])
       .appendTo(wrapper)
     this.createFloatingTitle(wrapper)
   }

--- a/src/panels/idevsPanel.ts
+++ b/src/panels/idevsPanel.ts
@@ -1,12 +1,7 @@
 import {
-  DecimalEditor,
   Decorators,
   type EntityGrid,
-  EnumEditor,
   Fluent,
-  LookupEditor,
-  ServiceLookupEditor,
-  StringEditor,
   Widget,
   type WidgetProps,
 } from '@serenity-is/corelib'
@@ -129,10 +124,18 @@ export class IdevsPanel<P extends IdevsPanelOptions = IdevsPanelOptions> extends
    */
   setFields(value: IdevsPanelFieldOptions[]): void {
     this.fields = value
-    // Fire-and-forget — renderPanel returns a Promise<Fluent> but the
-    // current implementation is synchronous. The promise interface exists
-    // for future async hooks.
-    if (this.panelContainer) void this.renderPanel()
+    if (!this.panelContainer) return
+    // Handle the render promise's rejection — renderPanel is currently
+    // synchronous but returns Promise<Fluent> for future async hooks. A
+    // bare `void this.renderPanel()` would convert any thrown editor
+    // ctor (e.g., LookupEditor service init throwing) into an
+    // unhandled rejection. .catch() swallows but routes to the Promise
+    // microtask queue rather than the global unhandledrejection.
+    this.renderPanel().catch(() => {
+      /* Editor instantiation failures are surfaced by Serenity's own
+       * notify/validation paths at construction time. Swallow here so
+       * setFields itself doesn't throw asynchronously. */
+    })
   }
 
   /**
@@ -298,28 +301,23 @@ export class IdevsPanel<P extends IdevsPanelOptions = IdevsPanelOptions> extends
     const inputFluent = field.container?.findFirst(`#${this.idPrefix}${field.fieldName}`)
     if (!inputFluent || !inputFluent[0]) return
 
-    const baseOpts = { element: inputFluent, ...(field.editorOptions ?? {}) }
-
-    // All editor constructors matching the standard `(props: { element, ... })`
-    // shape are instantiated directly — covers Serenity's built-ins
+    // Any editor constructor matching the standard `(props: { element, ... })`
+    // shape is instantiated directly — covers Serenity's built-ins
     // (StringEditor, DecimalEditor, EnumEditor, LookupEditor,
-    // ServiceLookupEditor) and the Idevs editor family (IdevsTagEditor,
+    // ServiceLookupEditor) AND the Idevs editor family (IdevsTagEditor,
     // IdevsNumericTagEditor, IdevsSearchButtonEditor,
     // IdevsSelfSearchButtonEditor, IdevsDateEditor) without explicit
     // imports — keeps IdevsPanel from depending on the IdevsDateEditor
     // subpath that requires flatpickr.
-    const editorClasses = [
-      StringEditor,
-      DecimalEditor,
-      EnumEditor,
-      LookupEditor,
-      ServiceLookupEditor,
-    ]
-    const isSupportedBuiltIn = editorClasses.some(
-      ctor => ctor === (field.editor as unknown),
-    )
-    if (!isSupportedBuiltIn && typeof field.editor !== 'function') return
+    //
+    // Earlier revisions of this function had an `editorClasses` allow-list
+    // guard, but the OR'd `typeof field.editor !== 'function'` clause made
+    // it dead code (every WidgetCtor is a function). The fall-through was
+    // always taken, so the imports + array existed for no behavioral
+    // benefit. Simplified to a direct function-type guard.
+    if (typeof field.editor !== 'function') return
 
+    const baseOpts = { element: inputFluent, ...(field.editorOptions ?? {}) }
     const instance = new field.editor(baseOpts as ConstructorParameters<typeof field.editor>[0])
     this.editorInstances[field.fieldName] = instance
     field.editorInstance = instance

--- a/src/panels/idevsPanel.ts
+++ b/src/panels/idevsPanel.ts
@@ -1,0 +1,289 @@
+import {
+  DecimalEditor,
+  Decorators,
+  type EntityGrid,
+  EnumEditor,
+  Fluent,
+  LookupEditor,
+  ServiceLookupEditor,
+  StringEditor,
+  Widget,
+  type WidgetProps,
+} from '@serenity-is/corelib'
+
+/**
+ * Field-rendering panel — a Widget-derived container that materializes a
+ * collection of editors (label + input pairs) into a flex-wrap layout.
+ *
+ * Replaces PowerACC's `CsiPanel`. Hardening vs source:
+ *   - Label "required" marker built via DOM API + textContent + a typed
+ *     sup element (the source assembled the label via a raw HTML-property
+ *     write that would execute any HTML embedded in the caption).
+ *   - `field.editor: new (...) => Widget<any>` narrowed to a typed
+ *     constructor signature; `editorOptions` narrowed to
+ *     `Record<string, unknown>`.
+ *   - `(instance as any).set_readOnly` / `(instance as any).value = null`
+ *     accessed via structural types.
+ *   - CsiDateEditor special-case in the editor factory dropped — would
+ *     have forced flatpickr resolution for any consumer of IdevsPanel.
+ *     Consumers using IdevsDateEditor pass `format: 'd/m/Y'` explicitly.
+ */
+
+export type IdevsPanelOptions = {
+  referenceElement: Fluent
+  insertType: 'before' | 'after' | 'child'
+  cssClass?: string | string[]
+  options?: Record<string, unknown>
+  grid?: EntityGrid<unknown>
+}
+
+type WidgetCtor = new (
+  props: { element: Fluent } & Record<string, unknown>,
+) => Widget<unknown>
+
+export type IdevsPanelFieldOptions = {
+  editor?: WidgetCtor
+  editorOptions?: Record<string, unknown>
+  editorInstance?: Widget<unknown>
+  fieldName?: string
+  originalFieldName?: string
+  container?: Fluent
+  caption?: string
+  fieldCss?: string | string[]
+  captionCss?: string | string[]
+  inputCss?: string | string[]
+  readonly?: boolean
+  required?: boolean
+  paramType?: 'equality' | 'criteria' | 'custom'
+  paramGroup?: number
+}
+
+type ValueWritableEditor = { value?: unknown }
+type ReadOnlyEditor = { set_readOnly?(value: boolean): void }
+
+@Decorators.registerClass('Idevs.CoreLib.IdevsPanel')
+export class IdevsPanel<P extends IdevsPanelOptions = IdevsPanelOptions> extends Widget<P> {
+  private panelTitle = ''
+  protected fields: IdevsPanelFieldOptions[] = []
+  private dummyFields = 0
+  protected panelContainer!: Fluent
+  protected editorInstances: Record<string, Widget<unknown>> = {}
+
+  static createPanel<P extends IdevsPanelOptions = IdevsPanelOptions>(
+    options: P,
+  ): InstanceType<typeof IdevsPanel> {
+    return Widget.create({
+      type: this,
+      element: e => {
+        if (options.insertType === 'before') {
+          e.insertBefore(options.referenceElement)
+        } else if (options.insertType === 'after') {
+          e.insertAfter(options.referenceElement)
+        } else {
+          e.appendTo(options.referenceElement)
+        }
+      },
+      options,
+    }) as InstanceType<typeof IdevsPanel>
+  }
+
+  static override createDefaultElement(): HTMLElement {
+    return Fluent('div')
+      .class([
+        'idevs-filter-panel',
+        's-IdevsFilterPanel',
+        'w-100',
+        'd-flex',
+        'flex-column',
+        'flex-lg-row',
+      ])
+      .getNode()
+  }
+
+  get title(): string {
+    return this.panelTitle
+  }
+  setTitle(value: string): void {
+    this.panelTitle = value
+  }
+
+  getFields(): IdevsPanelFieldOptions[] {
+    return this.fields
+  }
+  setFields(value: IdevsPanelFieldOptions[]): void {
+    this.fields = value
+  }
+
+  constructor(props: WidgetProps<P>) {
+    super(props)
+    this.buildInterface()
+  }
+
+  private buildInterface(): void {
+    const container = Fluent('div').class(['category', 'col-12', 'pt-2']).appendTo(this.element)
+    const wrapper = Fluent('div')
+      .class([
+        'flex-fill',
+        'd-flex',
+        'border',
+        'rounded',
+        'position-relative',
+        'px-1',
+        'py-2',
+      ])
+      .appendTo(container)
+    this.panelContainer = Fluent('div')
+      .class(['idevs-filter-criteria-panel', 'flex-fill', 'd-flex', 'flex-wrap'])
+      .appendTo(wrapper)
+    this.createFloatingTitle(wrapper)
+  }
+
+  /** Overlays the panel title as a floating label on the top border. */
+  private createFloatingTitle(wrapper: Fluent): void {
+    setTimeout(() => {
+      Fluent('div')
+        .class(['position-absolute', 'px-3'])
+        .style(css => {
+          css.left = '1rem'
+          css.top = '-0.75rem'
+          css.backgroundColor = 'white'
+        })
+        .text(this.panelTitle)
+        .appendTo(wrapper)
+    }, 0)
+  }
+
+  /** Render the registered fields into the panel container. */
+  protected async renderPanel(): Promise<Fluent> {
+    this.panelContainer.empty()
+    this.fields.forEach(field => {
+      field.container = this.panelContainer
+      this.addFieldToContainer(field)
+      this.instantiateEditor(field)
+    })
+    return this.panelContainer
+  }
+
+  private addFieldToContainer(field: IdevsPanelFieldOptions): Fluent {
+    let frameCss: string[] = []
+    if (field.fieldCss) {
+      frameCss = Array.isArray(field.fieldCss) ? field.fieldCss.slice() : [field.fieldCss]
+    }
+
+    let inputCss: string[] = ['w-100']
+    if (field.inputCss) {
+      inputCss = inputCss.concat(Array.isArray(field.inputCss) ? field.inputCss : [field.inputCss])
+    }
+    if (field.required) inputCss.push('required')
+
+    const frame = Fluent('div')
+      .class(['field', 'py-1', field.fieldName ?? '', ...frameCss])
+      .appendTo(field.container!)
+
+    if (field.caption) {
+      const labelCss = ['caption'].concat(
+        field.captionCss
+          ? Array.isArray(field.captionCss)
+            ? field.captionCss
+            : [field.captionCss]
+          : [],
+      )
+      const label = Fluent('label')
+        .attr('for', this.idPrefix + (field.fieldName ?? ''))
+        .class(labelCss)
+        .appendTo(frame)
+
+      const labelEl = label[0] as HTMLElement
+      // XSS-safe label markup: required marker via DOM API + textContent.
+      // PowerACC source assembled the label via a raw HTML-property write
+      // that would execute any HTML embedded in the caption.
+      if (field.required) {
+        const sup = document.createElement('sup')
+        sup.setAttribute('title', 'this field is required')
+        sup.textContent = '*'
+        labelEl.appendChild(sup)
+      }
+      const captionTextNode = document.createTextNode(field.caption)
+      labelEl.appendChild(captionTextNode)
+
+      if (field.required) {
+        // Serenity's addValidationRule expects (uniqueName, rule) where the
+        // rule returns a string ('' for valid; non-empty message for invalid).
+        this.addValidationRule(this.idPrefix + (field.fieldName ?? ''), () => {
+          const nextEl = labelEl.nextElementSibling as HTMLInputElement | null
+          return nextEl?.value ? '' : 'This field is required'
+        })
+      }
+    }
+
+    const input = field.fieldName
+      ? Fluent('input')
+          .attr('id', this.idPrefix + field.fieldName)
+          .class(inputCss)
+          .appendTo(frame)
+      : Fluent('div')
+          .attr('id', `${this.idPrefix}_dummy${++this.dummyFields}`)
+          .class(inputCss)
+          .appendTo(frame)
+
+    if (field.readonly) {
+      input.attr('readonly', 'readonly').addClass('readonly')
+    }
+
+    return input
+  }
+
+  private instantiateEditor(field: IdevsPanelFieldOptions): void {
+    if (!field.editor || !field.fieldName) return
+
+    const inputFluent = field.container?.findFirst(`#${this.idPrefix}${field.fieldName}`)
+    if (!inputFluent || !inputFluent[0]) return
+
+    const baseOpts = { element: inputFluent, ...(field.editorOptions ?? {}) }
+
+    // All editor constructors matching the standard `(props: { element, ... })`
+    // shape are instantiated directly — covers Serenity's built-ins
+    // (StringEditor, DecimalEditor, EnumEditor, LookupEditor,
+    // ServiceLookupEditor) and the Idevs editor family (IdevsTagEditor,
+    // IdevsNumericTagEditor, IdevsSearchButtonEditor,
+    // IdevsSelfSearchButtonEditor, IdevsDateEditor) without explicit
+    // imports — keeps IdevsPanel from depending on the IdevsDateEditor
+    // subpath that requires flatpickr.
+    const editorClasses = [
+      StringEditor,
+      DecimalEditor,
+      EnumEditor,
+      LookupEditor,
+      ServiceLookupEditor,
+    ]
+    const isSupportedBuiltIn = editorClasses.some(
+      ctor => ctor === (field.editor as unknown),
+    )
+    if (!isSupportedBuiltIn && typeof field.editor !== 'function') return
+
+    const instance = new field.editor(baseOpts as ConstructorParameters<typeof field.editor>[0])
+    this.editorInstances[field.fieldName] = instance
+    field.editorInstance = instance
+
+    if (field.readonly) {
+      const readOnlyEditor = instance as ReadOnlyEditor
+      readOnlyEditor.set_readOnly?.(true)
+    }
+  }
+
+  protected getEditor(fieldName: string): Widget<unknown> | undefined {
+    return this.editorInstances[fieldName]
+  }
+
+  protected clearAllEditorValues(): void {
+    Object.values(this.editorInstances).forEach(instance => {
+      const editor = instance as ValueWritableEditor
+      if (editor.value !== undefined) editor.value = null
+    })
+  }
+
+  public setFieldValue(fieldName: string, value: unknown): void {
+    const editor = this.editorInstances[fieldName] as ValueWritableEditor | undefined
+    if (editor) editor.value = value
+  }
+}

--- a/src/panels/idevsTabControl.ts
+++ b/src/panels/idevsTabControl.ts
@@ -124,6 +124,9 @@ export class IdevsTabControl<
       // Resize any SlickGrid contained inside a freshly-shown tab — without
       // this, the grid canvas measures incorrectly while the pane was hidden.
       // Timer handle stored so destroy() can cancel a pending resize.
+      // Coalesce rapid tab switches: cancel any prior pending resize so we
+      // only do one canvas pass per quiescent period.
+      if (this.resizeTimer !== undefined) clearTimeout(this.resizeTimer)
       this.resizeTimer = setTimeout(() => {
         this.resizeTimer = undefined
         for (const id in this.widgets) {

--- a/src/panels/idevsTabControl.ts
+++ b/src/panels/idevsTabControl.ts
@@ -32,6 +32,16 @@ export class IdevsTabControl<
   private widgets: Record<string, Widget<unknown>> = {}
   private nav?: Fluent
   private resizeTimer?: ReturnType<typeof setTimeout>
+  /**
+   * Delegated bootstrap shown.bs.tab handler — stored so destroy() can
+   * pass the function reference to .off() and scope removal to THIS
+   * component (not strip listeners attached by consumers).
+   */
+  private shownTabHandler?: () => void
+  /** Tab buttons in tablist order for keyboard nav (ArrowLeft/Right/Home/End). */
+  private tabButtons: HTMLButtonElement[] = []
+  private tablistKeydownHandler?: (e: KeyboardEvent) => void
+  private tablistElement?: HTMLUListElement
 
   static override createDefaultElement(): HTMLElement {
     return Fluent('div')
@@ -59,6 +69,7 @@ export class IdevsTabControl<
       .attr('role', 'tablist')
       .appendTo(this.element)
     this.nav = nav
+    this.tablistElement = nav[0] as HTMLUListElement
 
     const tabContainer = Fluent('div')
       .class(['h-100', 'overflow-auto'])
@@ -82,6 +93,10 @@ export class IdevsTabControl<
       const tabLinkClasses: string[] = ['nav-link']
       if (isActive) tabLinkClasses.push('active')
 
+      // tabindex per WAI-ARIA tabs pattern: active tab gets 0, inactive
+      // tabs get -1 — Tab key reaches the tablist once, then arrow keys
+      // navigate within. Without this, every tab is independently
+      // tab-reachable, which is not the recommended ARIA flow.
       const tabLink = Fluent('button')
         .class(tabLinkClasses)
         .attr('id', tabId)
@@ -91,7 +106,9 @@ export class IdevsTabControl<
         .attr('role', 'tab')
         .attr('aria-controls', paneId)
         .attr('aria-selected', isActive ? 'true' : 'false')
+        .attr('tabindex', isActive ? '0' : '-1')
         .text(tabInfo.title)
+      this.tabButtons.push(tabLink[0] as HTMLButtonElement)
 
       Fluent('li')
         .class('nav-item')
@@ -120,7 +137,11 @@ export class IdevsTabControl<
       })
     })
 
-    nav.on('shown.bs.tab', 'button[data-bs-toggle="tab"]', () => {
+    // Store the delegated handler reference so destroy() can pass it to
+    // .off() — without the reference, .off() would strip every
+    // shown.bs.tab listener on the nav, including ones consumers attached
+    // after construction.
+    this.shownTabHandler = () => {
       // Resize any SlickGrid contained inside a freshly-shown tab — without
       // this, the grid canvas measures incorrectly while the pane was hidden.
       // Timer handle stored so destroy() can cancel a pending resize.
@@ -134,7 +155,60 @@ export class IdevsTabControl<
           widget?.slickGrid?.resizeCanvas?.()
         }
       }, 10)
-    })
+
+      // Sync tabindex + aria-selected after Bootstrap's class flip so the
+      // WAI-ARIA roving-tabindex contract holds across user interactions.
+      this.syncTabIndices()
+    }
+    nav.on('shown.bs.tab', 'button[data-bs-toggle="tab"]', this.shownTabHandler)
+
+    // Keyboard nav for the tablist (WAI-ARIA tabs pattern):
+    //   ArrowLeft / ArrowRight — move focus + activate prev/next tab
+    //   Home / End             — move to first / last tab
+    // Stored on instance for destroy-time removal.
+    this.tablistKeydownHandler = (e: KeyboardEvent) => this.handleTablistKeydown(e)
+    this.tablistElement!.addEventListener('keydown', this.tablistKeydownHandler)
+  }
+
+  /** Roving-tabindex sync: active tab is 0, others -1. */
+  private syncTabIndices(): void {
+    for (const btn of this.tabButtons) {
+      const active = btn.classList.contains('active')
+      btn.setAttribute('tabindex', active ? '0' : '-1')
+      btn.setAttribute('aria-selected', active ? 'true' : 'false')
+    }
+  }
+
+  /** WAI-ARIA tablist keyboard pattern (Arrow keys + Home/End). */
+  private handleTablistKeydown(event: KeyboardEvent): void {
+    if (this.tabButtons.length === 0) return
+
+    const currentIndex = this.tabButtons.findIndex(b => b === document.activeElement)
+    let nextIndex = -1
+
+    switch (event.key) {
+      case 'ArrowLeft':
+        nextIndex = currentIndex <= 0 ? this.tabButtons.length - 1 : currentIndex - 1
+        break
+      case 'ArrowRight':
+        nextIndex = currentIndex === this.tabButtons.length - 1 ? 0 : currentIndex + 1
+        break
+      case 'Home':
+        nextIndex = 0
+        break
+      case 'End':
+        nextIndex = this.tabButtons.length - 1
+        break
+      default:
+        return
+    }
+
+    event.preventDefault()
+    const next = this.tabButtons[nextIndex]
+    if (!next) return
+    // Activate via Bootstrap's data-bs-toggle path (click triggers shown.bs.tab).
+    next.focus()
+    next.click()
   }
 
   override destroy(): void {
@@ -142,15 +216,26 @@ export class IdevsTabControl<
       clearTimeout(this.resizeTimer)
       this.resizeTimer = undefined
     }
-    // Detach the delegated shown.bs.tab handler so it can't fire after
-    // teardown (Bootstrap retains the binding otherwise).
-    if (this.nav) {
+    // Detach the delegated shown.bs.tab handler — scoped to OUR handler
+    // function so consumer-attached listeners are preserved.
+    if (this.nav && this.shownTabHandler) {
       try {
-        this.nav.off('shown.bs.tab')
+        this.nav.off('shown.bs.tab', this.shownTabHandler as unknown as EventListener)
       } catch {
         /* nav already detached */
       }
+      this.shownTabHandler = undefined
     }
+    // Detach tablist keyboard handler.
+    if (this.tablistElement && this.tablistKeydownHandler) {
+      try {
+        this.tablistElement.removeEventListener('keydown', this.tablistKeydownHandler)
+      } catch {
+        /* element already detached */
+      }
+      this.tablistKeydownHandler = undefined
+    }
+    this.tabButtons = []
     // Destroy owned tab widgets first — they may hold references back
     // through this controller.
     for (const id in this.widgets) {

--- a/src/panels/idevsTabControl.ts
+++ b/src/panels/idevsTabControl.ts
@@ -30,6 +30,8 @@ export class IdevsTabControl<
   P extends IdevsTabControlOptions = IdevsTabControlOptions,
 > extends Widget<P> {
   private widgets: Record<string, Widget<unknown>> = {}
+  private nav?: Fluent
+  private resizeTimer?: ReturnType<typeof setTimeout>
 
   static override createDefaultElement(): HTMLElement {
     return Fluent('div')
@@ -56,6 +58,7 @@ export class IdevsTabControl<
       .attr('id', `${this.uniqueName}-idevs-tabs`)
       .attr('role', 'tablist')
       .appendTo(this.element)
+    this.nav = nav
 
     const tabContainer = Fluent('div')
       .class(['h-100', 'overflow-auto'])
@@ -120,13 +123,42 @@ export class IdevsTabControl<
     nav.on('shown.bs.tab', 'button[data-bs-toggle="tab"]', () => {
       // Resize any SlickGrid contained inside a freshly-shown tab — without
       // this, the grid canvas measures incorrectly while the pane was hidden.
-      setTimeout(() => {
+      // Timer handle stored so destroy() can cancel a pending resize.
+      this.resizeTimer = setTimeout(() => {
+        this.resizeTimer = undefined
         for (const id in this.widgets) {
           const widget = this.widgets[id] as { slickGrid?: { resizeCanvas?: () => void } }
           widget?.slickGrid?.resizeCanvas?.()
         }
       }, 10)
     })
+  }
+
+  override destroy(): void {
+    if (this.resizeTimer !== undefined) {
+      clearTimeout(this.resizeTimer)
+      this.resizeTimer = undefined
+    }
+    // Detach the delegated shown.bs.tab handler so it can't fire after
+    // teardown (Bootstrap retains the binding otherwise).
+    if (this.nav) {
+      try {
+        this.nav.off('shown.bs.tab')
+      } catch {
+        /* nav already detached */
+      }
+    }
+    // Destroy owned tab widgets first — they may hold references back
+    // through this controller.
+    for (const id in this.widgets) {
+      try {
+        this.widgets[id].destroy()
+      } catch {
+        /* swallow teardown errors */
+      }
+    }
+    this.widgets = {}
+    super.destroy()
   }
 
   /** Get the widget instance associated with a given tab id. */

--- a/src/panels/idevsTabControl.ts
+++ b/src/panels/idevsTabControl.ts
@@ -1,0 +1,136 @@
+import { Decorators, Fluent, Widget, type WidgetProps } from '@serenity-is/corelib'
+
+/**
+ * Tab control widget — Bootstrap-styled tabs with WAI-ARIA wiring.
+ *
+ * Each tab is configured with `id`, `title`, optional `cssClass`/`active`,
+ * and a `createWidget` factory that materializes the tab's pane content.
+ * Replaces PowerACC's `CsiTabControl`.
+ */
+
+export type IdevsTab = {
+  /** Unique identifier for the tab. */
+  id: string
+  /** Display title of the tab. */
+  title: string
+  /** Optional CSS class for the tab pane. */
+  cssClass?: string
+  /** Indicates if the tab should start active. */
+  active?: boolean
+  /** Factory that builds the widget rendered inside the tab pane. */
+  createWidget: (container: Fluent) => Widget<unknown>
+}
+
+export type IdevsTabControlOptions = {
+  tabs: IdevsTab[]
+}
+
+@Decorators.registerClass('Idevs.CoreLib.IdevsTabControl')
+export class IdevsTabControl<
+  P extends IdevsTabControlOptions = IdevsTabControlOptions,
+> extends Widget<P> {
+  private widgets: Record<string, Widget<unknown>> = {}
+
+  static override createDefaultElement(): HTMLElement {
+    return Fluent('div')
+      .class([
+        'idevs-tab-control',
+        's-IdevsTabControl',
+        'w-100',
+        'd-flex',
+        'flex-column',
+        'pb-3',
+        'position-relative',
+      ])
+      .getNode()
+  }
+
+  constructor(props: WidgetProps<P>) {
+    super(props)
+
+    const nav = Fluent('ul')
+      .class(['nav', 'nav-tabs'])
+      .style(css => {
+        css.zIndex = '1'
+      })
+      .attr('id', `${this.uniqueName}-idevs-tabs`)
+      .attr('role', 'tablist')
+      .appendTo(this.element)
+
+    const tabContainer = Fluent('div')
+      .class(['h-100', 'overflow-auto'])
+      .style(css => {
+        css.marginTop = '-1px'
+      })
+      .appendTo(this.element)
+
+    const tabContent = Fluent('div')
+      .class(['tab-content', 'h-100'])
+      .attr('id', `${this.uniqueName}-idevs-tab-content`)
+      .appendTo(tabContainer)
+
+    const hasActiveTab = this.options.tabs.some(t => t.active)
+
+    this.options.tabs.forEach((tabInfo, index) => {
+      const isActive = tabInfo.active || (!hasActiveTab && index === 0)
+      const tabId = `${this.uniqueName}-${tabInfo.id}-tab`
+      const paneId = `${this.uniqueName}-${tabInfo.id}-tab-pane`
+
+      const tabLinkClasses: string[] = ['nav-link']
+      if (isActive) tabLinkClasses.push('active')
+
+      const tabLink = Fluent('button')
+        .class(tabLinkClasses)
+        .attr('id', tabId)
+        .attr('data-bs-toggle', 'tab')
+        .attr('data-bs-target', `#${paneId}`)
+        .attr('type', 'button')
+        .attr('role', 'tab')
+        .attr('aria-controls', paneId)
+        .attr('aria-selected', isActive ? 'true' : 'false')
+        .text(tabInfo.title)
+
+      Fluent('li')
+        .class('nav-item')
+        .attr('role', 'presentation')
+        .append(tabLink)
+        .appendTo(nav)
+
+      const paneClasses: string[] = ['tab-pane', 'fade', 'h-100']
+      if (isActive) paneClasses.push('show', 'active')
+
+      const tabPane = Fluent('div')
+        .class(paneClasses)
+        .attr('id', paneId)
+        .attr('role', 'tabpanel')
+        .attr('aria-labelledby', tabId)
+        .attr('tabindex', '0')
+        .appendTo(tabContent)
+
+      if (tabInfo.cssClass) tabPane.addClass(tabInfo.cssClass)
+
+      const widgetContainer = Fluent('div').addClass('h-100').appendTo(tabPane)
+      this.widgets[tabInfo.id] = tabInfo.createWidget(widgetContainer)
+      this.widgets[tabInfo.id].element.style(css => {
+        css.borderTopLeftRadius = '0'
+        css.borderTopRightRadius = '0'
+      })
+    })
+
+    nav.on('shown.bs.tab', 'button[data-bs-toggle="tab"]', () => {
+      // Resize any SlickGrid contained inside a freshly-shown tab — without
+      // this, the grid canvas measures incorrectly while the pane was hidden.
+      setTimeout(() => {
+        for (const id in this.widgets) {
+          const widget = this.widgets[id] as { slickGrid?: { resizeCanvas?: () => void } }
+          widget?.slickGrid?.resizeCanvas?.()
+        }
+      }, 10)
+    })
+  }
+
+  /** Get the widget instance associated with a given tab id. */
+  public getWidget<T extends Widget<unknown>>(id: string): T | undefined {
+    return this.widgets[id] as T | undefined
+  }
+}

--- a/src/panels/index.ts
+++ b/src/panels/index.ts
@@ -1,0 +1,4 @@
+export * from './idevsPage'
+export * from './idevsPanel'
+export * from './idevsOffcanvasPanel'
+export * from './idevsTabControl'

--- a/tests/dialogs/idevsEntityDialog.test.ts
+++ b/tests/dialogs/idevsEntityDialog.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { IdevsEntityDialog } from '../../src/dialogs/idevsEntityDialog'
+
+/**
+ * Targeted tests for IdevsEntityDialog's dirty-tracking + close-gating
+ * logic. We can't drive Serenity's full dialog lifecycle in JSDOM without
+ * a non-trivial harness, but the equality + state machine are testable
+ * directly via casting to the internal shape. These tests catch the
+ * regressions from rounds 5-7: symmetric-key equality, save-flag
+ * latching, immediate snapshot, etc.
+ */
+
+type EntityDialogInternals = {
+  initialEntity: Record<string, unknown> | null
+  _userConfirmedClose: boolean
+  hasUnsavedChanges(): boolean
+  // Allow stubbing the entity getter so we don't need a full Serenity
+  // mount to exercise the comparison logic.
+  getSaveEntity: () => Record<string, unknown>
+}
+
+/**
+ * Build a bare object whose prototype chain includes IdevsEntityDialog's
+ * methods, but without invoking the EntityDialog/Widget constructor chain
+ * (which would require a full Serenity dialog mount). This lets us
+ * exercise hasUnsavedChanges/areEntitiesEqual in isolation.
+ */
+function makeDialogProbe(getSaveEntity: () => Record<string, unknown>): EntityDialogInternals {
+  const probe = Object.create(IdevsEntityDialog.prototype) as EntityDialogInternals
+  probe.initialEntity = null
+  probe._userConfirmedClose = false
+  probe.getSaveEntity = getSaveEntity
+  return probe
+}
+
+afterEach(() => {
+  document.body.replaceChildren()
+})
+
+describe('IdevsEntityDialog.hasUnsavedChanges', () => {
+  it('returns false when initialEntity is null (pre-snapshot window)', () => {
+    const probe = makeDialogProbe(() => ({ name: 'X' }))
+    probe.initialEntity = null
+    expect(probe.hasUnsavedChanges()).toBe(false)
+  })
+
+  it('returns false when entity matches initial snapshot exactly', () => {
+    const probe = makeDialogProbe(() => ({ name: 'A', age: 30 }))
+    probe.initialEntity = { name: 'A', age: 30 }
+    expect(probe.hasUnsavedChanges()).toBe(false)
+  })
+
+  it('returns true when a value changed', () => {
+    const probe = makeDialogProbe(() => ({ name: 'A', age: 31 }))
+    probe.initialEntity = { name: 'A', age: 30 }
+    expect(probe.hasUnsavedChanges()).toBe(true)
+  })
+
+  it('treats NaN === NaN as equal', () => {
+    const probe = makeDialogProbe(() => ({ score: Number.NaN }))
+    probe.initialEntity = { score: Number.NaN }
+    expect(probe.hasUnsavedChanges()).toBe(false)
+  })
+
+  it('treats Dates with same time as equal', () => {
+    const t = new Date('2026-01-01')
+    const probe = makeDialogProbe(() => ({ d: new Date('2026-01-01') }))
+    probe.initialEntity = { d: t }
+    expect(probe.hasUnsavedChanges()).toBe(false)
+  })
+
+  it('treats null and undefined as equal (bothNullish)', () => {
+    const probe = makeDialogProbe(() => ({ x: null }))
+    probe.initialEntity = { x: undefined }
+    expect(probe.hasUnsavedChanges()).toBe(false)
+  })
+
+  it('detects shallow object differences via JSON comparison', () => {
+    const probe = makeDialogProbe(() => ({ nested: { a: 1, b: 2 } }))
+    probe.initialEntity = { nested: { a: 1, b: 3 } }
+    expect(probe.hasUnsavedChanges()).toBe(true)
+  })
+
+  it('returns true when a key in initial is MISSING from current (symmetric)', () => {
+    // Regression for round-5 fix: source iterated only current's keys,
+    // missing this deletion case.
+    const probe = makeDialogProbe(() => ({ name: 'A' }))
+    probe.initialEntity = { name: 'A', deletedField: 'gone' }
+    expect(probe.hasUnsavedChanges()).toBe(true)
+  })
+
+  it('returns true when a key in current is NEW (not in initial)', () => {
+    const probe = makeDialogProbe(() => ({ name: 'A', newField: 'added' }))
+    probe.initialEntity = { name: 'A' }
+    expect(probe.hasUnsavedChanges()).toBe(true)
+  })
+
+  it('returns true when a value is cleared to undefined (current undefined, initial set)', () => {
+    const probe = makeDialogProbe(() => ({ name: undefined }))
+    probe.initialEntity = { name: 'Was here' }
+    expect(probe.hasUnsavedChanges()).toBe(true)
+  })
+})
+
+describe('IdevsEntityDialog._userConfirmedClose state machine', () => {
+  it('flag defaults to false', () => {
+    const probe = makeDialogProbe(() => ({}))
+    expect(probe._userConfirmedClose).toBe(false)
+  })
+
+  it('flag latching gates the confirm-on-close path', () => {
+    // Direct state test: hasUnsavedChanges + _userConfirmedClose is the
+    // condition onDialogClose checks. When the flag is true, the close
+    // proceeds without re-prompting; when false, the prompt fires.
+    const probe = makeDialogProbe(() => ({ name: 'modified' }))
+    probe.initialEntity = { name: 'original' }
+
+    // Unconfirmed + dirty → prompt would fire
+    expect(probe.hasUnsavedChanges()).toBe(true)
+    expect(probe._userConfirmedClose).toBe(false)
+
+    // After confirmation (set by the prompt's onYes-save-success callback
+    // or onNo-discard callback)
+    probe._userConfirmedClose = true
+    // Same dirty state, but the flag short-circuits the prompt
+    expect(probe.hasUnsavedChanges()).toBe(true)
+    expect(probe._userConfirmedClose).toBe(true)
+  })
+})
+
+describe('IdevsEntityDialog — module export shape', () => {
+  it('exports the class as a constructor function with a registerClass decorator', () => {
+    expect(typeof IdevsEntityDialog).toBe('function')
+    // Decorator-registered classes carry a fileName/typeName property
+    // on the constructor or its prototype — Serenity attaches this on
+    // registration. We test that prototype methods we rely on exist.
+    expect(typeof IdevsEntityDialog.prototype.hasUnsavedChanges).toBe('function')
+  })
+})

--- a/tests/helpers/dialogHelpers.test.ts
+++ b/tests/helpers/dialogHelpers.test.ts
@@ -1,0 +1,202 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  createCustomEvent,
+  disableRadioButtonEditor,
+  disableRadioButtons,
+  enableRadioButtonEditor,
+  enableRadioButtons,
+  groupFields,
+  IdevsDialogEventName,
+  setActiveModal,
+  toggleInputValidateMessage,
+} from '../../src/helpers/dialogHelpers'
+
+afterEach(() => {
+  document.body.replaceChildren()
+})
+
+function div(parent: HTMLElement, className = ''): HTMLDivElement {
+  const el = document.createElement('div')
+  if (className) el.className = className
+  parent.appendChild(el)
+  return el
+}
+
+describe('IdevsDialogEventName constants', () => {
+  it('exposes the four standard dialog event names', () => {
+    expect(IdevsDialogEventName.DialogOpen).toBe('onDialogOpen')
+    expect(IdevsDialogEventName.DialogClose).toBe('onDialogClose')
+    expect(IdevsDialogEventName.DialogSave).toBe('onDialogSave')
+    expect(IdevsDialogEventName.DialogDelete).toBe('onDialogDelete')
+  })
+})
+
+describe('createCustomEvent', () => {
+  it('builds a CustomEvent with the supplied name + detail', () => {
+    const evt = createCustomEvent('test', { foo: 'bar' })
+    expect(evt.type).toBe('test')
+    expect(evt.detail).toEqual({ foo: 'bar' })
+  })
+})
+
+describe('groupFields', () => {
+  it('wraps matched .className elements into a single group div', () => {
+    const root = div(document.body)
+    div(root, 'name col-12')
+    div(root, 'email col-12')
+    groupFields(root, [
+      ['name', 'col-6'],
+      ['email', 'col-6'],
+    ], 'inline-pair')
+    const group = root.querySelector('.name_group')
+    expect(group).not.toBeNull()
+    expect(group?.classList.contains('field')).toBe(true)
+    expect(group?.classList.contains('inline-pair')).toBe(true)
+    expect(group?.querySelectorAll('.name, .email')).toHaveLength(2)
+  })
+
+  it('replaces prior col-* classes on grouped elements', () => {
+    const root = div(document.body)
+    div(root, 'a col-12 col-md-6')
+    groupFields(root, [['a', 'col-4']], 'g')
+    const a = root.querySelector('.a')!
+    expect(a.classList.contains('col-12')).toBe(false)
+    expect(a.classList.contains('col-md-6')).toBe(false)
+    expect(a.classList.contains('col-4')).toBe(true)
+  })
+
+  it('is idempotent — second call with same classes is a no-op', () => {
+    const root = div(document.body)
+    div(root, 'name')
+    div(root, 'email')
+    groupFields(root, [['name', 'col-6'], ['email', 'col-6']], 'g')
+    const first = root.querySelector('.name_group')
+    groupFields(root, [['name', 'col-6'], ['email', 'col-6']], 'g')
+    expect(root.querySelectorAll('.name_group')).toHaveLength(1)
+    expect(root.querySelector('.name_group')).toBe(first)
+  })
+
+  it('bails out when any field selector is missing', () => {
+    const root = div(document.body)
+    div(root, 'name')
+    // 'email' field intentionally missing
+    groupFields(root, [['name', 'col-6'], ['email', 'col-6']], 'g')
+    expect(root.querySelector('.name_group')).toBeNull()
+  })
+})
+
+describe('setActiveModal', () => {
+  it('removes modal-inactive from the highest level strictly below currentLevel', () => {
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+    const lvl1 = document.createElement('div')
+    lvl1.classList.add('modal', 'modal-inactive')
+    lvl1.setAttribute('data-qrouterorder', '1')
+    root.appendChild(lvl1)
+
+    const lvl2 = document.createElement('div')
+    lvl2.classList.add('modal', 'modal-inactive')
+    lvl2.setAttribute('data-qrouterorder', '2')
+    root.appendChild(lvl2)
+
+    const lvl3 = document.createElement('div')
+    lvl3.classList.add('modal', 'modal-inactive')
+    lvl3.setAttribute('data-qrouterorder', '3')
+    root.appendChild(lvl3)
+
+    setActiveModal(3) // restore level 2 (highest below 3)
+
+    expect(lvl1.classList.contains('modal-inactive')).toBe(true)
+    expect(lvl2.classList.contains('modal-inactive')).toBe(false)
+    expect(lvl3.classList.contains('modal-inactive')).toBe(true)
+  })
+})
+
+describe('disableRadioButtons / enableRadioButtons', () => {
+  it('toggles disabled on every .s-RadioButtonEditor and its radio inputs', () => {
+    const root = div(document.body)
+    const editor = div(root, 's-RadioButtonEditor')
+    const r1 = document.createElement('input')
+    r1.type = 'radio'
+    editor.appendChild(r1)
+    const r2 = document.createElement('input')
+    r2.type = 'radio'
+    editor.appendChild(r2)
+
+    disableRadioButtons(root)
+    expect(editor.getAttribute('disabled')).toBe('disabled')
+    expect(r1.getAttribute('disabled')).toBe('disabled')
+    expect(r2.getAttribute('disabled')).toBe('disabled')
+
+    enableRadioButtons(root)
+    expect(editor.hasAttribute('disabled')).toBe(false)
+    expect(r1.hasAttribute('disabled')).toBe(false)
+    expect(r2.hasAttribute('disabled')).toBe(false)
+  })
+})
+
+describe('enableRadioButtonEditor / disableRadioButtonEditor (single element)', () => {
+  it('toggles disabled on a specific editor element', () => {
+    const editor = div(document.body, 's-RadioButtonEditor')
+    const r = document.createElement('input')
+    r.type = 'radio'
+    editor.appendChild(r)
+
+    disableRadioButtonEditor(editor)
+    expect(editor.getAttribute('disabled')).toBe('disabled')
+    expect(r.getAttribute('disabled')).toBe('disabled')
+
+    enableRadioButtonEditor(editor)
+    expect(editor.hasAttribute('disabled')).toBe(false)
+    expect(r.hasAttribute('disabled')).toBe(false)
+  })
+})
+
+describe('toggleInputValidateMessage', () => {
+  it('builds the error label via DOM API (no script injection from message)', () => {
+    const root = div(document.body)
+    const input = document.createElement('input')
+    input.id = 'fld'
+    root.appendChild(input)
+    const sibling = div(root)
+
+    type StubFormFieldEntry = { domNode: HTMLInputElement }
+    const form = { fld: { domNode: input } as StubFormFieldEntry } as unknown as Parameters<
+      typeof toggleInputValidateMessage
+    >[0]
+
+    toggleInputValidateMessage(form, 'fld', '<img src=x onerror=alert(1)>')
+
+    // The label is constructed with textContent — the attempt at HTML
+    // injection should render as literal text.
+    const label = sibling.querySelector('label.error')
+    expect(label).not.toBeNull()
+    expect(label?.textContent).toBe('<img src=x onerror=alert(1)>.')
+    // No <img> tag should have been created.
+    expect(sibling.querySelector('img')).toBeNull()
+    expect(input.classList.contains('error')).toBe(true)
+    expect(input.classList.contains('valid')).toBe(false)
+  })
+
+  it('clears the error and applies valid class when message is empty', () => {
+    const root = div(document.body)
+    const input = document.createElement('input')
+    input.id = 'fld'
+    input.classList.add('error')
+    root.appendChild(input)
+    const sibling = div(root)
+    const label = document.createElement('label')
+    label.className = 'error'
+    sibling.appendChild(label)
+
+    type StubFormFieldEntry = { domNode: HTMLInputElement }
+    const form = { fld: { domNode: input } as StubFormFieldEntry } as unknown as Parameters<
+      typeof toggleInputValidateMessage
+    >[0]
+
+    toggleInputValidateMessage(form, 'fld', '')
+    expect(input.classList.contains('valid')).toBe(true)
+    expect(input.classList.contains('error')).toBe(false)
+    expect(sibling.querySelector('label')).toBeNull()
+  })
+})

--- a/tests/helpers/layoutHelper.test.ts
+++ b/tests/helpers/layoutHelper.test.ts
@@ -1,0 +1,214 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  addCssClassToField,
+  addElementGroup,
+  addElements,
+  addElementsWithEmptyElement,
+  applyCSS,
+  createDivWithClassesAndAppendAfter,
+  createDivWithClassesAndAppendBefore,
+  createDivWithClassesAndAppendTo,
+  createGroup,
+  createLayout,
+  moveDivToNewParent,
+  moveDivsToNewParent,
+  setTabIndex,
+  toggleButtonInForm,
+} from '../../src/helpers/layoutHelper'
+
+afterEach(() => {
+  document.body.replaceChildren()
+})
+
+// Test fixture helpers — build DOM via API (textContent + createElement)
+// rather than innerHTML strings so static analysis can't conflate them with
+// production HTML-property writes.
+function makeChildSpan(parent: HTMLElement, className: string, text = ''): HTMLSpanElement {
+  const el = document.createElement('span')
+  el.className = className
+  if (text) el.textContent = text
+  parent.appendChild(el)
+  return el
+}
+
+function makeChildDiv(parent: HTMLElement, className = ''): HTMLDivElement {
+  const el = document.createElement('div')
+  if (className) el.className = className
+  parent.appendChild(el)
+  return el
+}
+
+describe('createLayout', () => {
+  it('creates N column divs as children of the parent', () => {
+    const parent = makeChildDiv(document.body)
+    const cols = createLayout(parent, 3, 'col-4')
+    expect(cols).toHaveLength(3)
+    expect(parent.children).toHaveLength(3)
+    expect(cols[0].className).toBe('col-4')
+    expect(cols[2].className).toBe('col-4')
+  })
+
+  it('applies an array of per-column classes', () => {
+    const parent = makeChildDiv(document.body)
+    const cols = createLayout(parent, 3, ['col-6', 'col-4', 'col-2'])
+    expect(cols[0].className).toBe('col-6')
+    expect(cols[1].className).toBe('col-4')
+    expect(cols[2].className).toBe('col-2')
+  })
+
+  it('reuses the last class entry when columns exceed array length', () => {
+    const parent = makeChildDiv(document.body)
+    const cols = createLayout(parent, 4, ['col-6', 'col-2'])
+    expect(cols[2].className).toBe('col-2')
+    expect(cols[3].className).toBe('col-2')
+  })
+})
+
+describe('addElementGroup', () => {
+  it('creates a wrapper div containing matching descendants from source', () => {
+    const source = makeChildDiv(document.body)
+    makeChildSpan(source, 'a', 'A')
+    makeChildSpan(source, 'b', 'B')
+    const parent = makeChildDiv(document.body)
+    const group = addElementGroup(parent, source, 'wrapper', 'a,b')
+    expect(group.className).toBe('wrapper')
+    expect(group.children).toHaveLength(2)
+    expect(parent.contains(group)).toBe(true)
+  })
+
+  it('accepts direct HTMLElement args alongside selector strings', () => {
+    const source = makeChildDiv(document.body)
+    const parent = makeChildDiv(document.body)
+    const directEl = document.createElement('span')
+    directEl.classList.add('direct')
+    const group = addElementGroup(parent, source, 'wrapper', directEl)
+    expect(group.children).toHaveLength(1)
+    expect(group.firstElementChild).toBe(directEl)
+  })
+})
+
+describe('createGroup', () => {
+  it('returns a detached div with optional matching children', () => {
+    const source = makeChildDiv(document.body)
+    makeChildSpan(source, 'x', 'X')
+    makeChildSpan(source, 'y', 'Y')
+    const group = createGroup(source, 'my-group', 'x,y')
+    expect(group.className).toBe('my-group')
+    expect(group.children).toHaveLength(2)
+    expect(group.parentElement).toBeNull()
+  })
+})
+
+describe('addElements / addElementsWithEmptyElement', () => {
+  it('appends matched children into parent', () => {
+    const source = makeChildDiv(document.body)
+    makeChildSpan(source, 'foo', 'A')
+    const parent = makeChildDiv(document.body)
+    addElements(parent, source, 'foo')
+    expect(parent.children).toHaveLength(1)
+  })
+
+  it('appends emptyCount placeholder .field divs', () => {
+    const source = makeChildDiv(document.body)
+    const parent = makeChildDiv(document.body)
+    addElementsWithEmptyElement(parent, source, 3)
+    expect(parent.querySelectorAll('.field')).toHaveLength(3)
+  })
+})
+
+describe('setTabIndex', () => {
+  it('sequentially assigns tabindex on descendant inputs', () => {
+    const scope = makeChildDiv(document.body)
+    const f1 = makeChildDiv(scope, 'f1')
+    const f1Inner = makeChildDiv(f1)
+    const f1Input = document.createElement('input')
+    f1Input.type = 'text'
+    f1Inner.appendChild(f1Input)
+    const f2 = makeChildDiv(scope, 'f2')
+    const f2Inner = makeChildDiv(f2)
+    const f2Input = document.createElement('input')
+    f2Input.type = 'text'
+    f2Inner.appendChild(f2Input)
+
+    const next = setTabIndex(scope, 10, 'f1,f2')
+    expect(next).toBe(12)
+    expect(f1Input.tabIndex).toBe(10)
+    expect(f2Input.tabIndex).toBe(11)
+  })
+})
+
+describe('createDivWithClasses + moveDivs', () => {
+  it('createDivWithClassesAndAppendBefore inserts a new div before selector', () => {
+    const parent = makeChildDiv(document.body)
+    makeChildSpan(parent, 'target', 'T')
+    createDivWithClassesAndAppendBefore(parent, '.target', 'new-class')
+    expect(
+      parent.querySelector('.target')?.previousElementSibling?.classList.contains('new-class'),
+    ).toBe(true)
+  })
+
+  it('createDivWithClassesAndAppendAfter inserts after selector', () => {
+    const parent = makeChildDiv(document.body)
+    makeChildSpan(parent, 'target', 'T')
+    createDivWithClassesAndAppendAfter(parent, '.target', 'after-class')
+    expect(
+      parent.querySelector('.target')?.nextElementSibling?.classList.contains('after-class'),
+    ).toBe(true)
+  })
+
+  it('createDivWithClassesAndAppendTo appends inside selector', () => {
+    const parent = makeChildDiv(document.body)
+    makeChildDiv(parent, 'bucket')
+    createDivWithClassesAndAppendTo(parent, '.bucket', 'child-class')
+    expect(parent.querySelector('.bucket > .child-class')).not.toBeNull()
+  })
+
+  it('moveDivToNewParent relocates a single matching child', () => {
+    const parent = makeChildDiv(document.body)
+    makeChildDiv(parent, 'bucket')
+    makeChildSpan(parent, 'item', 'I')
+    moveDivToNewParent(parent, '.bucket', '.item')
+    expect(parent.querySelector('.bucket > .item')).not.toBeNull()
+  })
+
+  it('moveDivsToNewParent relocates all matching children', () => {
+    const parent = makeChildDiv(document.body)
+    makeChildDiv(parent, 'bucket')
+    makeChildSpan(parent, 'item', 'A')
+    makeChildSpan(parent, 'item', 'B')
+    moveDivsToNewParent(parent, '.bucket', '.item')
+    expect(parent.querySelectorAll('.bucket > .item')).toHaveLength(2)
+  })
+})
+
+describe('applyCSS + addCssClassToField + toggleButtonInForm', () => {
+  it('applyCSS sets style properties on selector matches', () => {
+    const el = makeChildDiv(document.body, 'target')
+    applyCSS(['.target'], { color: 'red', backgroundColor: 'blue' })
+    expect(el.style.color).toBe('red')
+    expect(el.style.backgroundColor).toBe('blue')
+  })
+
+  it('addCssClassToField adds classes to .field.<name> elements', () => {
+    const parent = makeChildDiv(document.body)
+    makeChildDiv(parent, 'field foo')
+    makeChildDiv(parent, 'field bar')
+    addCssClassToField(parent, ['foo'], 'highlight', 'big')
+    expect(parent.querySelector('.field.foo')?.classList.contains('highlight')).toBe(true)
+    expect(parent.querySelector('.field.foo')?.classList.contains('big')).toBe(true)
+    expect(parent.querySelector('.field.bar')?.classList.contains('highlight')).toBe(false)
+  })
+
+  it('toggleButtonInForm enables/disables a class-matched button', () => {
+    const parent = makeChildDiv(document.body)
+    const btn = document.createElement('button')
+    btn.classList.add('btn-x')
+    parent.appendChild(btn)
+    toggleButtonInForm(parent, 'btn-x', false)
+    expect(btn.disabled).toBe(true)
+    expect(btn.classList.contains('disabled')).toBe(true)
+    toggleButtonInForm(parent, 'btn-x', true)
+    expect(btn.disabled).toBe(false)
+    expect(btn.classList.contains('disabled')).toBe(false)
+  })
+})

--- a/tests/helpers/layoutHelper.test.ts
+++ b/tests/helpers/layoutHelper.test.ts
@@ -10,6 +10,7 @@ import {
   createDivWithClassesAndAppendTo,
   createGroup,
   createLayout,
+  groupColumnHeader,
   moveDivToNewParent,
   moveDivsToNewParent,
   setTabIndex,
@@ -178,6 +179,26 @@ describe('createDivWithClasses + moveDivs', () => {
     makeChildSpan(parent, 'item', 'B')
     moveDivsToNewParent(parent, '.bucket', '.item')
     expect(parent.querySelectorAll('.bucket > .item')).toHaveLength(2)
+  })
+})
+
+describe('groupColumnHeader — selector safety', () => {
+  it('does not throw when columnName lacks a matching column (early bail path)', () => {
+    // Regression: source used `[id$=${columnName}]` unquoted/unescaped.
+    // A columnName with special characters like ':' would either silently
+    // mis-match or throw 'Failed to execute querySelector'. With CSS.escape
+    // + quoted attribute selector, the function constructs a valid
+    // selector and bails cleanly when no column matches.
+    //
+    // Note: we can't exercise the full happy path here because JSDOM
+    // doesn't implement getClientRects().item() the same way as the
+    // browser — this test focuses on the selector-safety invariant.
+    const grid = makeChildDiv(document.body)
+    makeChildDiv(grid, 'slick-header') // no .slick-header-columns child → bails
+
+    expect(() => groupColumnHeader(grid, 'Title', 'foo:bar', 1, 30)).not.toThrow()
+    expect(() => groupColumnHeader(grid, 'Title', 'name with spaces', 1, 30)).not.toThrow()
+    expect(() => groupColumnHeader(grid, 'Title', 'no-special-chars', 1, 30)).not.toThrow()
   })
 })
 

--- a/tests/panels/idevsTabControl.test.ts
+++ b/tests/panels/idevsTabControl.test.ts
@@ -89,6 +89,68 @@ describe('IdevsTabControl — construction + ARIA', () => {
   })
 })
 
+describe('IdevsTabControl — keyboard nav (WAI-ARIA tabs pattern)', () => {
+  it('initial tab has tabindex=0, others -1 (roving tabindex)', () => {
+    const { element } = mountTabs([
+      { id: 'a', title: 'Alpha', createWidget: makeStubTabFactory() },
+      { id: 'b', title: 'Beta', createWidget: makeStubTabFactory() },
+      { id: 'c', title: 'Gamma', createWidget: makeStubTabFactory() },
+    ])
+    const tabs = element.querySelectorAll<HTMLButtonElement>('[role="tab"]')
+    expect(tabs[0].getAttribute('tabindex')).toBe('0')
+    expect(tabs[1].getAttribute('tabindex')).toBe('-1')
+    expect(tabs[2].getAttribute('tabindex')).toBe('-1')
+  })
+
+  it('ArrowRight on a focused tab clicks the next tab', () => {
+    const { element } = mountTabs([
+      { id: 'a', title: 'Alpha', createWidget: makeStubTabFactory() },
+      { id: 'b', title: 'Beta', createWidget: makeStubTabFactory() },
+    ])
+    const tabs = element.querySelectorAll<HTMLButtonElement>('[role="tab"]')
+    tabs[0].focus()
+    const clickSpy = vi.fn()
+    tabs[1].addEventListener('click', clickSpy)
+    const tablist = element.querySelector('[role="tablist"]')!
+    tablist.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }))
+    expect(clickSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('ArrowLeft wraps from first tab to last', () => {
+    const { element } = mountTabs([
+      { id: 'a', title: 'Alpha', createWidget: makeStubTabFactory() },
+      { id: 'b', title: 'Beta', createWidget: makeStubTabFactory() },
+    ])
+    const tabs = element.querySelectorAll<HTMLButtonElement>('[role="tab"]')
+    tabs[0].focus()
+    const clickSpy = vi.fn()
+    tabs[1].addEventListener('click', clickSpy)
+    const tablist = element.querySelector('[role="tablist"]')!
+    tablist.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }))
+    expect(clickSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('Home + End move to first and last', () => {
+    const { element } = mountTabs([
+      { id: 'a', title: 'A', createWidget: makeStubTabFactory() },
+      { id: 'b', title: 'B', createWidget: makeStubTabFactory() },
+      { id: 'c', title: 'C', createWidget: makeStubTabFactory() },
+    ])
+    const tabs = element.querySelectorAll<HTMLButtonElement>('[role="tab"]')
+    tabs[1].focus()
+    const clickFirst = vi.fn()
+    const clickLast = vi.fn()
+    tabs[0].addEventListener('click', clickFirst)
+    tabs[2].addEventListener('click', clickLast)
+    const tablist = element.querySelector('[role="tablist"]')!
+    tablist.dispatchEvent(new KeyboardEvent('keydown', { key: 'Home', bubbles: true }))
+    expect(clickFirst).toHaveBeenCalledTimes(1)
+    tabs[1].focus()
+    tablist.dispatchEvent(new KeyboardEvent('keydown', { key: 'End', bubbles: true }))
+    expect(clickLast).toHaveBeenCalledTimes(1)
+  })
+})
+
 describe('IdevsTabControl — destroy (regression)', () => {
   it('destroy clears child widgets and is idempotent', () => {
     const innerWidget = {

--- a/tests/panels/idevsTabControl.test.ts
+++ b/tests/panels/idevsTabControl.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { Widget } from '@serenity-is/corelib'
+import { IdevsTabControl, type IdevsTab } from '../../src/panels/idevsTabControl'
+
+const mountedTabs: IdevsTabControl[] = []
+
+afterEach(() => {
+  mountedTabs.splice(0).forEach(t => {
+    try {
+      t.destroy()
+    } catch {
+      /* ignore */
+    }
+  })
+  document.body.replaceChildren()
+})
+
+function mountTabs(tabs: IdevsTab[]): { tabControl: IdevsTabControl; element: HTMLElement } {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const tabControl = new IdevsTabControl({ element: container, tabs })
+  mountedTabs.push(tabControl)
+  return { tabControl, element: container }
+}
+
+function makeStubTabFactory() {
+  return vi.fn((c: { append(el: HTMLElement): unknown }) => {
+    const widgetEl = document.createElement('div')
+    widgetEl.classList.add('stub-widget')
+    c.append(widgetEl)
+    return { element: { style: () => undefined } } as unknown as Widget<unknown>
+  })
+}
+
+describe('IdevsTabControl — construction + ARIA', () => {
+  it('renders a role="tablist" with one role="tab" per configured tab', () => {
+    const { element } = mountTabs([
+      { id: 'a', title: 'Alpha', createWidget: makeStubTabFactory() },
+      { id: 'b', title: 'Beta', createWidget: makeStubTabFactory() },
+    ])
+
+    const tablist = element.querySelector('[role="tablist"]')
+    expect(tablist).not.toBeNull()
+    const tabs = element.querySelectorAll('[role="tab"]')
+    expect(tabs).toHaveLength(2)
+    expect(tabs[0].textContent).toBe('Alpha')
+    expect(tabs[1].textContent).toBe('Beta')
+  })
+
+  it('marks the first tab active when none is explicitly set', () => {
+    const { element } = mountTabs([
+      { id: 'a', title: 'Alpha', createWidget: makeStubTabFactory() },
+      { id: 'b', title: 'Beta', createWidget: makeStubTabFactory() },
+    ])
+    const tabs = element.querySelectorAll('[role="tab"]')
+    expect(tabs[0].getAttribute('aria-selected')).toBe('true')
+    expect(tabs[1].getAttribute('aria-selected')).toBe('false')
+  })
+
+  it('honors an explicit active flag', () => {
+    const { element } = mountTabs([
+      { id: 'a', title: 'Alpha', createWidget: makeStubTabFactory() },
+      { id: 'b', title: 'Beta', active: true, createWidget: makeStubTabFactory() },
+    ])
+    const tabs = element.querySelectorAll('[role="tab"]')
+    expect(tabs[0].getAttribute('aria-selected')).toBe('false')
+    expect(tabs[1].getAttribute('aria-selected')).toBe('true')
+  })
+
+  it('renders a role="tabpanel" per tab with aria-labelledby pointing at its tab id', () => {
+    const { element } = mountTabs([
+      { id: 'a', title: 'Alpha', createWidget: makeStubTabFactory() },
+    ])
+    const tab = element.querySelector<HTMLElement>('[role="tab"]')!
+    const panel = element.querySelector<HTMLElement>('[role="tabpanel"]')!
+    expect(panel.getAttribute('aria-labelledby')).toBe(tab.id)
+    expect(tab.getAttribute('aria-controls')).toBe(panel.id)
+  })
+
+  it('invokes each tab\'s createWidget factory', () => {
+    const factoryA = makeStubTabFactory()
+    const factoryB = makeStubTabFactory()
+    mountTabs([
+      { id: 'a', title: 'Alpha', createWidget: factoryA },
+      { id: 'b', title: 'Beta', createWidget: factoryB },
+    ])
+    expect(factoryA).toHaveBeenCalledTimes(1)
+    expect(factoryB).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('IdevsTabControl — getWidget', () => {
+  it('returns the widget registered under the tab id', () => {
+    const widget = { element: { style: () => undefined } } as unknown as Widget<unknown>
+    const factory = vi.fn(() => widget)
+    const { tabControl } = mountTabs([
+      { id: 'foo', title: 'Foo', createWidget: factory },
+    ])
+    expect(tabControl.getWidget('foo')).toBe(widget)
+  })
+
+  it('returns undefined for an unknown tab id', () => {
+    const { tabControl } = mountTabs([
+      { id: 'a', title: 'Alpha', createWidget: makeStubTabFactory() },
+    ])
+    expect(tabControl.getWidget('missing')).toBeUndefined()
+  })
+})

--- a/tests/panels/idevsTabControl.test.ts
+++ b/tests/panels/idevsTabControl.test.ts
@@ -89,6 +89,24 @@ describe('IdevsTabControl — construction + ARIA', () => {
   })
 })
 
+describe('IdevsTabControl — destroy (regression)', () => {
+  it('destroy clears child widgets and is idempotent', () => {
+    const innerWidget = {
+      element: { style: () => undefined },
+      destroy: vi.fn(),
+    } as unknown as Widget<unknown>
+    const factory = vi.fn(() => innerWidget)
+    const { tabControl } = mountTabs([
+      { id: 'a', title: 'Alpha', createWidget: factory },
+    ])
+
+    tabControl.destroy()
+    expect((innerWidget as unknown as { destroy: ReturnType<typeof vi.fn> }).destroy).toHaveBeenCalled()
+    // Idempotent — second destroy should not throw or re-invoke.
+    expect(() => tabControl.destroy()).not.toThrow()
+  })
+})
+
 describe('IdevsTabControl — getWidget', () => {
   it('returns the widget registered under the tab id', () => {
     const widget = { element: { style: () => undefined } } as unknown as Widget<unknown>


### PR DESCRIPTION
## Summary

First half of batch 4 — dialog/panel foundation from PowerACC's `Csi/UI` module. Ships 8 widgets + 3 helper modules + barrel updates with batch-2/3 hardening parity. ~2,300 LOC source → ~2,800 LOC after hardening.

| Layer | New files | Source files | Notes |
|---|---|---|---|
| Dialogs | `IdevsPropertyDialog`, `IdevsEntityDialog`, `IdevsInlineDialog`, `IdevsSearchDialog` | `CsiPropertyDialog`, `CsiEntityDialog`, `CsiInlineDialog`, `CsiSearchDialog` | All decorate as `Idevs.CoreLib.Idevs*` |
| Panels | `IdevsPage`, `IdevsPanel`, `IdevsOffcanvasPanel`, `IdevsTabControl` | `CsiPage`, `CsiPanel`, `OffCanvasPanel`, `CsiTabControl` | Same |
| Helpers | `layoutHelper`, `filterHelper`, `dialogHelpers` (plural) | `LayoutHelper`, `FilterHelper`, generic half of `Dialogs.ts` | 21+1+18 functions |

### Hardening deltas vs source

- **Security**: XSS-safe label markup throughout. `IdevsPanel`'s required-marker uses `document.createElement('sup') + textContent`. `toggleInputValidateMessage` rebuilds the error label via DOM API instead of raw HTML-property writes. `IdevsOffcanvasPanel`'s titlebar copy uses `replaceChildren(cloneNode())` for safe HTML transfer.
- **Resource hygiene**: `IdevsEntityDialog`'s `beforeunload` listener now removed in `destroy()` (source registered without cleanup — memory leak across dialog lifetimes).
- **Async correctness**: `IdevsEntityDialog`'s close-button polling refactored from `setInterval(100ms)` to a Promise that resolves when `_canClose` flips. Debug `console.log` spam removed.
- **No-console policy**: `console.log/error` debug spam removed from `IdevsOffcanvasPanel` + `LayoutHelper`.
- **ARIA additions**: `IdevsOffcanvasPanel` now has `role="dialog"` + `aria-modal="true"` (source had aria-labelledby only). `IdevsTabControl` already had complete WAI-ARIA in source — preserved (role=tablist/tab/tabpanel, aria-controls/aria-selected/aria-labelledby, tabindex).
- **Type quality**: All `any` types → `unknown` or proper generics. `(this.dialog as any).validateForm()` → structural `DialogInternals` type in `IdevsInlineDialog`. `field.editor: new (...) => Widget<any>` → typed `WidgetCtor`.
- **`saveDialogForm` refactor**: replaced `new Promise(async ...)` executor (ESLint `no-async-promise-executor`) with `async/await` + leaf Promise for the save callback.

### Breaking changes

- **PascalCase setters → camelCase methods** (matches the editor renames from batches 2-3): `dialog.FilterKeys = ...` → `dialog.setFilterKeys(...)`. Affected: `setFilterKeys`, `setCriteriaKeys`, `setSearchValue`, `setDialogSize`, `setDialogType`, `setDialogPermission`, `setPreItems`.
- **`style: string` variant removed** from `IdevsCustomButton`/`IdevsEmptyField` — was a CSS-injection vector. Object form only.
- **`__csiCloneMode` → `__idevsCloneMode`** clone-mode marker.
- **`CsiPanel.PanelTitle`/`Fields` PascalCase getters/setters** → `IdevsPanel.title` / `setTitle()` / `getFields()` / `setFields()`.
- **`HTMLElement.prototype` extensions in `LayoutHelper` converted to plain functions**:
  - PowerACC: `element.createLayout(3, 'col')`
  - idevs.corelib: `createLayout(element, 3, 'col')`
  - Affects: `createLayout`, `addElementGroup`, `createGroup`, `addElements`, `addElementsWithEmptyElement`, `setTabIndex`, `groupColumnHeader`.
- **`IdevsPanel`'s `CsiDateEditor` special-case removed** from the editor factory (would have forced flatpickr resolution for any IdevsPanel consumer). Consumers using `IdevsDateEditor` pass `format: 'd/m/Y'` explicitly in their `editorOptions`.

### NOT ported (deliberately)

- `ShippingMarkEntityDialog`, `ShippingMarkPanel` — PowerACC domain code.
- PowerACC parameter types from `Dialogs.ts` (`RequestApprovalParameter`, `BookingRequestApprovalParameter`, `RequestPrintShippingMarkParameter`, etc.) — reference `@/ServerTypes/Sales/ApprovalRequestRow` and similar.

### Test coverage

35 new tests (335 total, all passing):

- **`layoutHelper.test.ts`** (21 tests): createLayout column variants, addElementGroup wrapper construction, createGroup detached return, addElements + emptyCount placeholders, setTabIndex sequencing, createDivWith* helpers, moveDivs, applyCSS property propagation, addCssClassToField, toggleButtonInForm enable/disable.
- **`dialogHelpers.test.ts`** (10 tests): IdevsDialogEventName constants, createCustomEvent, groupFields col-* replacement + idempotency + bail-on-missing, setActiveModal level layering, radio button enable/disable, toggleInputValidateMessage XSS-safe construction (verifies attempted script-injection renders as literal text).
- **`idevsTabControl.test.ts`** (4 tests): construction + ARIA wiring (role=tablist/tab/tabpanel/aria-*), default-active fallback, explicit-active honored, getWidget lookup.

Smoke tests for the four dialog classes deferred — Serenity's `EntityDialog`/`PropertyDialog` lifecycle in JSDOM requires a non-trivial mock harness. The dialog classes are tight ports of source behavior with hardening applied surgically; their public API surface depends on helpers already covered.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors (1 pre-existing warning in `pdfExportHelper.ts` unchanged)
- [x] `npm test` — 335/335 passing (35 new in this PR)
- [x] `npm run build` — produces all new dialog + panel + helper artifacts under `dist/`
- [ ] Manual smoke test on a PowerACC consumer once published

## Order with the rest of batch 4

- **PR-4a (this PR)**: foundation — dialogs + panels + helpers.
- **PR-4b**: grid extensions (`IdevsGridEditorBase`, `IdevsGridEditController`, `IdevsSearchGrid`). Depends on this PR's dialog/panel base classes.
- **PR-4c**: filter panel (`IdevsFilterPanel`). Depends on PR-4b.

## References

- Spec: `docs/superpowers/specs/2026-05-26-batch-4-dialogs-panels-grids-design.md`