### PR TITLE
chore(release): v1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,47 +7,86 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-> Tracks work landed on `main` after `v1.1.1` that has not yet been tagged. The unreleased grid-extensions work (batches 2–4b) is described in `MIGRATION.md` under `1.4.x → 1.5.0`; the entry below covers only the most recent hardening round on top of that work.
+## [1.5.0] - 2026-05-30
 
-### PR-4b grid extensions — round-19 hardening (12 findings)
+> Covers work landed on `main` after `v1.1.1`: editor, dialog, panel, grid,
+> helper, and hardening work for the 1.5.0 release.
 
-Multi-agent review (`pr-review-toolkit`) of the merged batch-4b grid extensions identified 3 Critical, 6 Important, and 3 Suggestion-level findings. All 12 addressed in commit `ed55acc`. Public-facing changes consumers should know about:
+### Added
 
-#### Changed
+- **Editor additions**:
+  - `IdevsTagEditor` with combobox/listbox ARIA, casing support, required-state validation, read-only support, keyboard navigation, and idempotent cleanup.
+  - `IdevsDateEditor` at `@idevs/corelib/editors/idevsDateEditor`, with `flatpickr` as an optional peer, ISO-value normalization, user-format display, modal placement handling, validation-class sync, and read-only handling.
+  - `IdevsNumericTagEditor`, `IdevsSearchButtonEditor`, `IdevsSelfSearchButtonEditor`, `SlickEditorBase`, `SlickSearchButtonEditor`, and `SlickSelfSearchButtonEditor`.
+  - Internal editor helpers for masked patterns, required markers, validation mirroring, and self-search result rendering.
+- **Dialog and panel additions**:
+  - `IdevsPropertyDialog`, `IdevsEntityDialog`, `IdevsInlineDialog`, `IdevsSearchDialog`.
+  - `IdevsPage`, `IdevsPanel`, `IdevsOffcanvasPanel`, `IdevsTabControl`.
+- **Grid additions**:
+  - Root exports: `IdevsEntityGrid`, `IdevsSearchGrid`, `IdevsGridEditController`.
+  - Optional-subpath exports: `IdevsSelectableEntityGrid` and `IdevsGridEditorBase`.
+  - Custom cell-editor registry via `IdevsGridEditController.registerCellEditor(...)`.
+- **Helper ports**:
+  - `layoutHelper`, `filterHelper`, and plural `dialogHelpers` modules.
+  - Root helper exports extended with layout/dialog/filter helpers; async layout `getElementHeight` is exported as `waitForElementHeight` to avoid a name clash.
+- **Optional peer dependency coverage**:
+  - `flatpickr` for `IdevsDateEditor`.
+  - `@serenity-is/extensions` for selectable/grid-editor subpath grids.
+- **Test coverage and docs**:
+  - New Vitest suites for editors, self-search controllers, dialogs, panels, helpers, grids, grid-controller type assertions, and regression scenarios.
+  - Design/spec and review documents for the 1.5.0 component work.
 
-- **`IdevsGridEditorBase.deleteCurrentRow` no longer rethrows on repaint failure.** If `slickGrid.invalidate()` / `updateRowCount()` / `render()` throws after `view.deleteItem` already succeeded, the row stays in `_deletedRows` (data-layer delete already happened), the method logs + calls `notifyError('The row was deleted but the grid display could not be refreshed. …')`, and returns cleanly. Subclasses that previously wrapped the call in `try/catch` can drop that.
-- **Click handler now commits the active editor on same-row cell-to-cell clicks too** (round-18 #1 follow-up). Previously round-17 only gated the commit by `row !== args.row` — editing row 0 cell 1 and clicking row 0 cell 2 still hit the data-loss path. Widened to `row OR cell change`; row-level `validate()` stays row-only.
-- **`addButtonClick` commit → validate → addItem ordering** is now covered by behavioral tests (round-19 #7), preventing future re-introduction of the round-17 #2 stale-row validation bug.
+### Changed
 
-#### Added
+- The public root barrel now exports `editors`, `dialogs`, `grids`, `panels`, expanded `helpers`, `utils`, and `types`.
+- Legacy PascalCase assignment APIs were converted to camelCase methods where applicable, with compatibility shims retained on the dialog/search/grid surfaces documented in `MIGRATION.md`.
+- `IdevsDateEditor` is intentionally not re-exported from the `editors` barrel so consumers that do not use dates are not forced to resolve `flatpickr`.
+- `IdevsPanel` no longer assumes a legacy date editor format; consumers using `IdevsDateEditor` should pass `format: 'd/m/Y'` explicitly when they need that display format.
+- `IdevsGridEditController` identifies mounted custom editors by a controller-owned marker attribute instead of class-name regex matching. Custom renderers must use the provided `appendEditorChild(child)` callback.
+- `IdevsGridEditController` header navigation matches `column.id` first, then `column.field`, and logs a warning when header `data-id` matches no visible column.
+- `IdevsGridEditController.notifyCellChange` now catches and logs throwing host subscribers after the editor state has already been committed.
+- `IdevsGridEditorBase.deleteCurrentRow` no longer rethrows if grid repaint fails after the data-layer delete has succeeded; it records the deleted row, logs, and notifies the user.
+- `IdevsGridEditorBase` cell-click handling now commits active edits before any same-row or different-row cell navigation. Failed commits block navigation.
+- `IdevsGridEditorBase.addButtonClick` preserves commit -> row-validate -> addItem ordering.
+- `IdevsSearchGrid.handleEditItemError` is now invoked through a safe wrapper that downgrades throwing overrides to logged warnings.
+- `package.json` now includes subpath exports for optional date/grid modules and peer metadata for optional peers.
+- `eslint.config.mjs` and test TypeScript config were extended for the larger source and test surface.
+- `package-lock.json` now scopes the `glob` override to `@serenity-is/tsbuild` for CVE-2025-64756.
 
-- **`IdevsGridEditController.findColumnByDataId` warn-on-miss telemetry.** When a header's `data-id` matches no column's `id` OR `field`, the controller now logs `[IdevsGridEditController] findColumnByDataId: header data-id matches no visible column id or field: <dataId>`. Navigation behavior unchanged (returns `-1`, caller continues iterating). Helps diagnose column-config drift that previously silently turned cells into non-editable.
-- **`IdevsGridEditController.notifyCellChange` try/catch around the host notify.** A throwing `onCellChange` subscriber on the host grid no longer rips up through the editor's `change` handler. Logged as `[IdevsGridEditController] onCellChange subscriber threw; editor state already committed:` — editor state stays consistent because textContent / cleanup writes already ran before notify.
-- **`isDefinedCellTarget` internal type guard** in `idevsGridEditorBase.ts` replaces a fragile `args!` non-null assertion in the click handler with a compiler-enforced narrowed `clickTarget` local.
+### Fixed
 
-#### Fixed
+- XSS risks in new editor, dialog, panel, grid, and validation-message rendering paths by using DOM APIs and `textContent` instead of raw markup writes.
+- Data-loss paths in grid editing where navigation could tear down an active editor before commit or validate stale row state before adding a row.
+- Lifecycle leaks from unremoved window/document/SlickGrid listeners, mutation observers, self-search modal/dropdown listeners, and grid-editor subscriber arrays.
+- Read-only, focus, validation, and modal-placement edge cases in date, tag, search-button, self-search, dialog, and grid controls.
+- SlickGrid editor cleanup drift, including stale editor marker/classes during toggle-off, row changes, and cell changes.
+- Null-guard and private-field access issues across dialogs, panels, search grids, grid editors, and helper code.
+- Async correctness issues in dialog close handling, search dialog opening, self-search focus timers, and grid edit error handling.
 
-- **`IdevsGridEditController` editor classes** — Integer / Decimal / String editor change handlers now have inline cross-reference comments pointing at the shared `cleanupCellEditorClasses` helper to prevent future drift (the Lookup `text-white` leak fixed in round-11 #3 originated from this kind of drift).
-- **`tryCommitEditor` failure path documentation** clarified: on `commitCurrentEdit() === false` the SlickGrid contract is that the editor's own `validate()` rendered the user-visible message; the controller intentionally does not add a second `notifyError` toast. Telemetry-only `console.warn` retained.
+### Removed
 
-#### Tests
+- Application-domain modules and types were intentionally not included: `ShippingMark*` modules and approval/report parameter types that reference application-specific server rows.
+- The application-specific `CustomerProductPriceEditor` special case was removed from grid editor dispatch; consumers should register app-specific editors through `registerCellEditor(...)`.
+- Layout helper prototype extensions were not carried forward; affected helpers are plain exported functions.
+- Raw CSS-string style variants were removed from `IdevsInlineDialog.IdevsCustomButton.style` and `IdevsInlineDialog.IdevsEmptyField.style`; use `Partial<CSSStyleDeclaration>`.
+- Internal self-search/helper modules are not part of the public barrel and should not be imported by consumers.
 
-- **+9 net new tests**, total now 556 + 1 skipped (was 547 + 1 skipped at end of round-18).
-- Replaced brittle "no `||` between if and validate" structural style-pin test with **5 behavioral runtime tests** exercising the captured click handler through `setupGridEventHandlers` (different-row click, same-row different-cell click, same-cell no-op, failing-commit blocks navigation, no-flag-on-block).
-- Added bidirectional `findColumnByDataId` collision tests (id-first regardless of column order) + warn-on-miss + no-warn-on-match.
-- Added strict-TS compile-only assertions for the `id?: string` field on `GridColumn` introduced in round-17 #4.
-- Added 2 behavioral ordering tests for `addButtonClick`: commit → validate → addItem on success; commit → validate (no addItem) on validate-fail.
+### Migration
 
-#### Migration
-
-- See `MIGRATION.md` under `### Post-review hardening (PR-4b rounds 6-19)` for the full consumer-facing contract list, including the marker-based editor identification contract for custom `registerCellEditor(...)` renderers.
+- See `MIGRATION.md` for the full migration path since `v1.1.1`, including:
+  - `1.1.1 -> 1.5.0` overview.
+  - `1.1.x -> 1.2.0` editor/search-button changes.
+  - `1.2.x -> 1.3.0` self-search changes.
+  - `1.3.x -> 1.4.0` dialog/panel/helper changes.
+  - `1.4.x -> 1.5.0` grid changes and PR-4b hardening contracts.
 
 ---
 
 ## [1.1.1] - 2026-05-24
 
 ### Added
-- **Csi/UI port — batch 1/4** (primitives from PowerACC):
+
+- **Component primitives**:
   - `helpers/windowHelper.ts` — `isSmallDevice()` responsive media-query check.
   - `helpers/processQueryButtons.ts` — `addProcessQueryButtons()` factory for paired Query/Clear toolbar buttons.
   - `types/gridEditableMode.ts` — `GridEditableMode` discriminated union (`Full` / `Off` / `Some`).
@@ -57,6 +96,7 @@ Multi-agent review (`pr-review-toolkit`) of the merged batch-4b grid extensions 
 ## [1.1.0] - 2026-05-23
 
 ### Added
+
 - **Vitest test harness** with jsdom environment; unit tests for `utils/format`, `utils/dom`, `globals` date proxy helpers, `DropdownToolButton`, and `pdfExportHelper`.
 - **GitHub Actions CI** (`.github/workflows/ci.yml`) running typecheck, lint, test, and build on PRs and pushes to `main`.
 - **`@idevs/corelib/globals` subpath export** for opt-in prototype patches. Prepares for the 2.0.0 removal of the implicit side-effect import from the root entry.
@@ -65,12 +105,14 @@ Multi-agent review (`pr-review-toolkit`) of the merged batch-4b grid extensions 
 - **`MIGRATION.md`** with the deprecation guide and the 2.0.0 outlook.
 
 ### Changed
+
 - `doExportPdf` and `doExportExcel` now return `Promise<void>` and surface server errors. Existing callers continue to work but should `await` (or `.catch`) to capture failures.
 - `prepublishOnly` now gates publish behind typecheck, lint, and tests.
 - `@serenity-is/corelib` and `@serenity-is/sleekgrid` are now `peerDependencies` (range `>=8.8.6 <9` / `>=1.9.6 <2`) instead of regular `dependencies`. `jquery` and `jspdf` are declared as optional peers.
 - TypeScript `strictNullChecks` is now enabled. The rest of the strict-family flags remain off pending further migration.
 
 ### Fixed
+
 - **XSS** in `DropdownToolButton.addSideButtonItem` — replaced HTML template interpolation with DOM-API construction (`buildSideButtonElement`), with invalid CSS-class tokens dropped as defense-in-depth.
 - **XSS** in `pdfExportHelper.showFluentPdfPreview` — dialog title now uses `textContent` via the new `__buildPreviewDialog` helper. Bonus: the close-button glyph also moved from `innerHTML` to `textContent`.
 - **Filename injection** in `doExportPdf` download — `options.reportName` is sanitized before use as `<a download>` via the new `__sanitizeDownloadName` helper.
@@ -81,10 +123,12 @@ Multi-agent review (`pr-review-toolkit`) of the merged batch-4b grid extensions 
 - Stale `toastr` entry removed from `tsconfig.types` (the `@types/toastr` package wasn't installed and broke `tsc --noEmit`).
 
 ### Deprecated
+
 - `IdevsContentResponse.FileName` — use `DownloadName` (matches the server DTO). Removal in 2.0.0.
 - Implicit `import './globals'` in the root entry — opt in via `import '@idevs/corelib/globals'` instead. Removal in 2.0.0.
 
 ### Compatibility
+
 - **No breaking changes.** Consumers on `^1.0.5` upgrade by running `npm update @idevs/corelib`.
 - A future 2.0.0 will remove the deprecated paths and align wire DTO casing with the .NET DTO (`viewName` → `ViewName`, etc.). See `MIGRATION.md`.
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,69 @@
 # Migration Guide
 
+## 1.1.1 → 1.5.0 — component batches 2-4b
+
+This section is the at-a-glance migration map for all work landed after
+`v1.1.1`. The detailed version-lane sections below break the same work into
+the planned minor releases:
+
+- `1.1.x → 1.2.0`: editor foundations, tag/date editors, search-button editor,
+  numeric tag editor, and SleekGrid editor adapters.
+- `1.2.x → 1.3.0`: self-search button editor and self-search modal/dropdown
+  controllers.
+- `1.3.x → 1.4.0`: dialog, panel, layout, filter, and generic dialog-helper
+  ports.
+- `1.4.x → 1.5.0`: grid, selectable grid, grid editor base, grid edit
+  controller, and grid hardening contracts.
+
+### Required consumer checks
+
+- If you import `IdevsDateEditor`, use the subpath import and make sure your
+  app installs/resolves `flatpickr`:
+
+  ```ts
+  import { IdevsDateEditor } from '@idevs/corelib/editors/idevsDateEditor'
+  ```
+
+- If you import `IdevsSelectableEntityGrid` or `IdevsGridEditorBase`, use the
+  documented grid subpath imports and make sure your Serenity app resolves
+  `@serenity-is/extensions` from Serenity's local `.dotnet` package.
+- Replace direct legacy imports with `Idevs*` imports from `@idevs/corelib`,
+  `@idevs/corelib/editors`, or the documented optional subpaths.
+- Prefer camelCase methods added by this port (`setFilterKeys`,
+  `setCriteriaKeys`, `setDialogSize`, `setSearchValue`, etc.). Compatibility
+  shims exist where noted below, but new code should not add new PascalCase
+  assignment usage.
+- Custom grid cell editors registered through
+  `IdevsGridEditController.registerCellEditor(...)` must mount editor DOM
+  through the provided `appendEditorChild(child)` render callback.
+- Code that depended on application-domain modules (`ShippingMark*`, approval
+  request parameter types, app-specific `CustomerProductPriceEditor` dispatch)
+  must keep those modules in the consuming application or register app-specific
+  replacements.
+
+### Main breaking or behavior-changing items since 1.1.1
+
+- `layoutHelper` prototype extensions were not ported. Use exported helper
+  functions instead of `HTMLElement.prototype` methods.
+- `IdevsSearchButtonEditor` and `IdevsSelfSearchButtonEditor` rename
+  legacy PascalCase/asymmetric setters to camelCase methods:
+  `filterKeys = ...` → `setFilterKeys(...)` and
+  `CriteriaKeys = ...` → `setCriteriaKeys(...)`.
+- `SlickEditorBase.validate()` returns `{ valid: boolean; msg?: string }`.
+  Compare missing messages with `msg === undefined`, not `msg === null`.
+- `IdevsInlineDialog.IdevsCustomButton.style` and
+  `IdevsInlineDialog.IdevsEmptyField.style` accept
+  `Partial<CSSStyleDeclaration>` only; raw CSS strings are no longer accepted.
+- Clone-mode marker changed to `__idevsCloneMode`.
+- `IdevsPanel` does not hard-code a `d/m/Y` default for date editors. Pass
+  `format: 'd/m/Y'` explicitly when you need that display format.
+- `IdevsGridEditorBase.deleteCurrentRow` no longer rethrows grid repaint
+  failures after a successful data-layer delete.
+- `IdevsGridEditorBase` commits active cell edits before any same-row or
+  different-row cell navigation; failed commits block navigation.
+- `IdevsGridEditController.notifyCellChange` catches/logs throwing host
+  subscribers after the editor state is already committed.
+
 ## 1.4.x → 1.5.0 — batch 4b grid extensions
 
 ### New grid classes
@@ -8,17 +72,17 @@ All in `src/grids/`. Three are exported from the root `@idevs/corelib` barrel; t
 
 **Root-importable** (`import { ... } from '@idevs/corelib'`):
 
-- `IdevsEntityGrid` (decorator: `Idevs.CoreLib.IdevsEntityGrid`) — replaces PowerACC's `CsiEntityGrid`. Thin EntityGrid wrapper that forces `renderAllRows: true` in `getSlickOptions`.
-- `IdevsSearchGrid` (decorator: `Idevs.CoreLib.IdevsSearchGrid`) — replaces PowerACC's `CsiSearchGrid`. Abstract base for search-result grids with filter-driven on-demand loading, authorization-gated `editItem`, quick-search toggling, and click-to-highlight row UX.
-- `IdevsGridEditController` (decorator: `Idevs.CoreLib.IdevsGridEditController`) — replaces PowerACC's `GridEditController`. In-cell editor controller for an EntityGrid. Supports Integer, Decimal, Boolean, Lookup, ServiceLookup, plain-string editors out of the box, and exposes a public `registerCellEditor(editorType, factory)` registry for additional types.
+- `IdevsEntityGrid` (decorator: `Idevs.CoreLib.IdevsEntityGrid`) — thin EntityGrid wrapper that forces `renderAllRows: true` in `getSlickOptions`.
+- `IdevsSearchGrid` (decorator: `Idevs.CoreLib.IdevsSearchGrid`) — abstract base for search-result grids with filter-driven on-demand loading, authorization-gated `editItem`, quick-search toggling, and click-to-highlight row UX.
+- `IdevsGridEditController` (decorator: `Idevs.CoreLib.IdevsGridEditController`) — in-cell editor controller for an EntityGrid. Supports Integer, Decimal, Boolean, Lookup, ServiceLookup, plain-string editors out of the box, and exposes a public `registerCellEditor(editorType, factory)` registry for additional types.
 
 **Subpath-only** (`import { ... } from '@idevs/corelib/grids/<name>'`):
 
-- `IdevsSelectableEntityGrid` (decorator: `Idevs.CoreLib.IdevsSelectableEntityGrid`) — replaces PowerACC's `CsiSelectableEntityGrid`. Selectable entity grid with `renderAllRows: true`. Import:
+- `IdevsSelectableEntityGrid` (decorator: `Idevs.CoreLib.IdevsSelectableEntityGrid`) — selectable entity grid with `renderAllRows: true`. Import:
   ```ts
   import { IdevsSelectableEntityGrid } from '@idevs/corelib/grids/idevsSelectableEntityGrid'
   ```
-- `IdevsGridEditorBase` (decorator: `Idevs.CoreLib.IdevsGridEditorBase`) — replaces PowerACC's `CsiGridEditorBase`. Editable grid base with per-row validation, Tab/Enter cell navigation, add/delete/move-up/move-down/expand toolbar buttons, grid expansion (form-field hide/show), row-change + add-button subscribers, and `set_readOnly` toolbar mirror. Import:
+- `IdevsGridEditorBase` (decorator: `Idevs.CoreLib.IdevsGridEditorBase`) — editable grid base with per-row validation, Tab/Enter cell navigation, add/delete/move-up/move-down/expand toolbar buttons, grid expansion (form-field hide/show), row-change + add-button subscribers, and `set_readOnly` toolbar mirror. Import:
   ```ts
   import { IdevsGridEditorBase } from '@idevs/corelib/grids/idevsGridEditorBase'
   ```
@@ -37,9 +101,10 @@ Two of the new grids extend Serenity's `SelectableEntityGrid` / `GridEditorBase`
 
 ### API additions (PascalCase setters preserved as compatibility shims)
 
-Consistent with the batch-4a hardening pattern: PowerACC PascalCase property setters → camelCase methods as the canonical API; PascalCase getters/setters preserved as deprecated compatibility shims.
+Consistent with the batch-4a hardening pattern: legacy PascalCase property setters → camelCase methods as the canonical API; PascalCase getters/setters preserved as deprecated compatibility shims.
 
 `IdevsSearchGrid`:
+
 - `FilterKeys` → `setFilterKeys()` / `getFilterKeys()`
 - `CriteriaKeys` → `setCriteriaKeys()` / `getCriteriaKeys()`
 - `SearchValue` → `setSearchValue()` (write-only; source had no getter)
@@ -47,24 +112,27 @@ Consistent with the batch-4a hardening pattern: PowerACC PascalCase property set
 - `PreItems` → `setPreItems()` / `getPreItems()`
 
 New overridable hooks on `IdevsSearchGrid`:
+
 - `handleEditItemError(err, entityOrId, phase?)` — protected hook invoked when `editItem` fails to load or open a dialog. `phase` distinguishes `'dialog-load'` (rejected `getDialogType()` Promise — typically transient: chunk-load / dynamic-import / module 404) from `'dialog-open'` (dialog constructor threw OR `loadByIdAndOpenDialog` rejected — typically terminal). Default implementation calls `notifyError('Unable to open editor dialog.')` + structured `console.warn`. Backward compat: 2-arg overrides (`(err, entityOrId)`) still type-check — `phase` is optional. Override-throws are caught by the internal `safeHandleEditItemError` wrapper and downgraded so they don't become unhandled rejections.
 
 `IdevsGridEditorBase`:
+
 - `IsFirstClicked` → `setIsFirstClicked()` / `getIsFirstClicked()`
 - `DeletedRows` (getter only) → `getDeletedRows()` — now returns a deep copy via `structuredClone` when available (falls back to shallow spread + warn on `DataCloneError` for non-cloneable `TEntity` shapes)
 
 New overridable hooks on `IdevsGridEditorBase`:
+
 - `formatValidationMessage(errors)` — return `{ text, escapeHtml }` payload forwarded to `notifyError`. Default joins messages with `\n` and `escapeHtml: true`. Override to opt into HTML formatting (consumers MUST sanitize themselves; see XSS hardening notes below).
-- `getOrderField()` — return the per-row field name used as the order key by `moveCurrentRowUp` / `moveCurrentRowDown`. Default `'ItemNo'` for PowerACC parity; return `null` to disable order-field swapping entirely.
+- `getOrderField()` — return the per-row field name used as the order key by `moveCurrentRowUp` / `moveCurrentRowDown`. Default `'ItemNo'` for legacy behavior parity; return `null` to disable order-field swapping entirely.
 
 ### Security / behavior hardening highlights
 
-- **XSS — IdevsGridEditController**: every `targetElement.innerHTML = userValue` write in the editor change handlers is now `target.textContent`. The PowerACC source's String editor case rendered user-typed text straight to innerHTML.
+- **XSS — IdevsGridEditController**: every `targetElement.innerHTML = userValue` write in the editor change handlers is now `target.textContent`. The legacy String editor case rendered user-typed text straight to innerHTML.
 - **XSS — IdevsGridEditorBase**: `notifyError(messages.join('<br />'), ..., { escapeHtml: false })` replaced with the default `escapeHtml: true` and `\n` separator. Subclasses wanting HTML formatting must opt in via the new `formatValidationMessage(errors)` override hook.
 - **Domain leak — IdevsGridEditorBase**: the hardcoded `currentItem.ItemNo` field in `moveCurrentRowUp` / `moveCurrentRowDown` is replaced with an overridable `getOrderField()` hook (defaults to `'ItemNo'` for behavior parity, return `null` to disable order-field swapping entirely).
-- **Domain leak — IdevsGridEditController**: the PowerACC-specific `case "PowerACC.MasterData.CustomerProductPriceEditor"` is dropped from the editor dispatch switch. Replaced with a public `registerCellEditor(editorType, factory)` registry — consumers register their own editor types without subclassing or patching.
+- **Domain leak — IdevsGridEditController**: the application-specific `CustomerProductPriceEditor` special case is dropped from the editor dispatch switch. Replaced with a public `registerCellEditor(editorType, factory)` registry — consumers register their own editor types without subclassing or patching.
 - **Private-field access**: `slickGrid["_options"]` reads replaced with `slickGrid.getOptions()` (`IdevsGridEditController`). `["combobox"]["container"]` private Select2 lookups now go through a typed structural shape with a null guard.
-- **Dead code**: `IdevsGridEditorBase` drops the source's `validateCell` private method (never called) and the `csiUpdateInterface` method from `IdevsSelectableEntityGrid` (empty-body setTimeout).
+- **Dead code**: `IdevsGridEditorBase` drops the source's `validateCell` private method (never called) and an empty-body setTimeout update hook from `IdevsSelectableEntityGrid`.
 - **Lifecycle**: `IdevsGridEditController` adds a public `destroy()` method (source never unsubscribed its 5 SlickGrid event handlers — long-lived host grids accumulated dead subscriptions). `IdevsGridEditorBase` extends the source's `destroy()` to clear subscriber arrays in addition to draining `eventCleanup`.
 - **Null guards**: `IdevsSearchGrid.setSearchValue` defensively checks `toolbar?.element?.findFirst`. `IdevsSearchGrid.onClick` null-guards `.closest('.slick-viewport')` and uses `target.closest('.slick-row')` to walk to the real row element (the source's `target.parentElement` was the cell, not the row, when cells contain nested formatter markup). `IdevsGridEditorBase.toggleGridExpansion` and `calculateAvailableHeight` null-guard `.closest()` calls so the grid can render outside the expected `form > .category > <grid>` chain.
 
@@ -93,9 +161,9 @@ The initial port (rounds 1-5) shipped the surface above. The follow-on review ro
 
 - **`handleEditItemError(err, entityOrId, phase?)`** is now invoked through a `safeHandleEditItemError` wrapper that catches override-throws. Subclasses overriding the hook don't need their own try/catch — a throwing override is downgraded to a logged warning instead of becoming an unhandled rejection.
 
-### NOT ported (stay in PowerACC)
+### Not included
 
-- `ShippingMark*` modules — PowerACC domain code.
+- `ShippingMark*` modules — application-domain code.
 
 ---
 
@@ -105,26 +173,26 @@ The initial port (rounds 1-5) shipped the surface above. The follow-on review ro
 
 All in `src/dialogs/`, exported from the public barrel.
 
-- `IdevsPropertyDialog` (decorator: `Idevs.CoreLib.IdevsPropertyDialog`) — replaces PowerACC's `CsiPropertyDialog`. Extends Serenity `PropertyDialog`; integrates with modal-stack helpers; dispatches `onDialogClose` CustomEvent.
-- `IdevsEntityDialog` (decorator: `Idevs.CoreLib.IdevsEntityDialog`) — replaces PowerACC's `CsiEntityDialog`. Adds dirty-check confirm-on-close, clone mode (`__idevsCloneMode` marker, renamed from `__csiCloneMode`), and a custom close button.
-- `IdevsInlineDialog` (decorator: `Idevs.CoreLib.IdevsInlineDialog`) — replaces PowerACC's `CsiInlineDialog`. Embeds an EntityDialog inline (non-modal) with custom buttons + empty field slots.
-- `IdevsSearchDialog` (decorator: `Idevs.CoreLib.IdevsSearchDialog`) — replaces PowerACC's `CsiSearchDialog`. Abstract base for search-result dialogs with grid integration + clear/new toolbar buttons.
+- `IdevsPropertyDialog` (decorator: `Idevs.CoreLib.IdevsPropertyDialog`) — extends Serenity `PropertyDialog`; integrates with modal-stack helpers; dispatches `onDialogClose` CustomEvent.
+- `IdevsEntityDialog` (decorator: `Idevs.CoreLib.IdevsEntityDialog`) — adds dirty-check confirm-on-close, clone mode (`__idevsCloneMode` marker), and a custom close button.
+- `IdevsInlineDialog` (decorator: `Idevs.CoreLib.IdevsInlineDialog`) — embeds an EntityDialog inline (non-modal) with custom buttons + empty field slots.
+- `IdevsSearchDialog` (decorator: `Idevs.CoreLib.IdevsSearchDialog`) — abstract base for search-result dialogs with grid integration + clear/new toolbar buttons.
 
 ### New panel classes
 
 All in `src/panels/`, exported from the public barrel.
 
-- `IdevsPage` (decorator: `Idevs.CoreLib.IdevsPage`) — replaces PowerACC's `CsiPage`. Page-level container; no preact dependency (source used `render(<CsiTitle/>)`; ported with plain DOM).
-- `IdevsPanel` (decorator: `Idevs.CoreLib.IdevsPanel`) — replaces PowerACC's `CsiPanel`. Field-rendering container with label + input pairs.
-- `IdevsOffcanvasPanel` (decorator: `Idevs.CoreLib.IdevsOffcanvasPanel`) — replaces PowerACC's `OffCanvasPanel`. Bootstrap offcanvas slide-out hosting an EntityDialog.
-- `IdevsTabControl` (decorator: `Idevs.CoreLib.IdevsTabControl`) — replaces PowerACC's `CsiTabControl`. Bootstrap tabs with full WAI-ARIA wiring.
+- `IdevsPage` (decorator: `Idevs.CoreLib.IdevsPage`) — page-level container implemented with plain DOM.
+- `IdevsPanel` (decorator: `Idevs.CoreLib.IdevsPanel`) — field-rendering container with label + input pairs.
+- `IdevsOffcanvasPanel` (decorator: `Idevs.CoreLib.IdevsOffcanvasPanel`) — Bootstrap offcanvas slide-out hosting an EntityDialog.
+- `IdevsTabControl` (decorator: `Idevs.CoreLib.IdevsTabControl`) — Bootstrap tabs with full WAI-ARIA wiring.
 
 ### New helpers
 
-- `src/helpers/layoutHelper.ts` — 21 DOM/layout utilities ported from PowerACC's `LayoutHelper.ts`. **Behavioral change**: the source attached 7 of these as `HTMLElement.prototype` methods; they are now plain functions:
+- `src/helpers/layoutHelper.ts` — 21 DOM/layout utilities. **Behavioral change**: the legacy implementation attached 7 of these as `HTMLElement.prototype` methods; they are now plain functions:
 
   ```ts
-  // PowerACC:
+  // before:
   element.createLayout(3, 'col')
 
   // idevs.corelib:
@@ -138,26 +206,26 @@ All in `src/panels/`, exported from the public barrel.
 
   Note: `layoutHelper.ts`'s async polling `getElementHeight` is re-exported as `waitForElementHeight` to disambiguate from `utils/dom.ts`'s synchronous variant.
 
-- `src/helpers/filterHelper.ts` — `clearFilter(filters)` ported from PowerACC's `FilterHelper.ts`.
+- `src/helpers/filterHelper.ts` — `clearFilter(filters)`.
 
-- `src/helpers/dialogHelpers.ts` (plural — new file, leaves existing `dialogHelper.ts` untouched) — generic dialog/modal helpers from PowerACC's `Dialogs.ts`. Exports: `setDialogSize`, `fixMobileCloseDialog`, `groupFields`, `setActiveModal`, `setInactiveModal`, `disableRadioButtons`, `enableRadioButtons`, `enableRadioButtonEditor`, `disableRadioButtonEditor`, `enableEditor`, `disableEditor`, `disableToolbarButton`, `enableToolbarButton`, `toggleInputValidateMessage`, `addSearchButton`, `SearchDialogOptions`, `IdevsDialogEventName`, `createCustomEvent`.
+- `src/helpers/dialogHelpers.ts` (plural — new file, leaves existing `dialogHelper.ts` untouched) — generic dialog/modal helpers. Exports: `setDialogSize`, `fixMobileCloseDialog`, `groupFields`, `setActiveModal`, `setInactiveModal`, `disableRadioButtons`, `enableRadioButtons`, `enableRadioButtonEditor`, `disableRadioButtonEditor`, `enableEditor`, `disableEditor`, `disableToolbarButton`, `enableToolbarButton`, `toggleInputValidateMessage`, `addSearchButton`, `SearchDialogOptions`, `IdevsDialogEventName`, `createCustomEvent`.
 
-### NOT ported (stay in PowerACC)
+### Not included
 
-- `ShippingMarkEntityDialog`, `ShippingMarkPanel` — PowerACC's shipping-mark module.
-- The PowerACC-domain types from `Dialogs.ts`: `NameValueCollection`, `RequestApprovalDetailParameter`, `IvnRequestApprovalDetailParameter`, `BookingRequestApprovalDetailParameter`, `RequestApprovalParameter`, `RequestOnedateReportParameter`, `InventoryRequestApprovalParameter`, `BookingRequestApprovalParameter`, `RequestPrintShippingMarkParameter`. These reference `@/ServerTypes/Sales/ApprovalRequestRow` and similar — domain code stays in PowerACC.
+- `ShippingMarkEntityDialog`, `ShippingMarkPanel` — application-specific shipping-mark module.
+- Application-domain types from the legacy dialog helpers: `NameValueCollection`, `RequestApprovalDetailParameter`, `IvnRequestApprovalDetailParameter`, `BookingRequestApprovalDetailParameter`, `RequestApprovalParameter`, `RequestOnedateReportParameter`, `InventoryRequestApprovalParameter`, `BookingRequestApprovalParameter`, `RequestPrintShippingMarkParameter`. These reference application-specific server rows and should stay in the consuming application.
 
 ### API additions (PascalCase setters preserved as compatibility shims)
 
 - Dialogs now expose **camelCase methods** as the preferred API: `setFilterKeys()`, `setCriteriaKeys()`, `setSearchValue()`, `setDialogSize()`, `setDialogType()`, `setDialogPermission()`, `setPreItems()`.
-- The PowerACC **PascalCase assignment setters** (`dialog.FilterKeys = ...`, `dialog.CriteriaKeys = ...`, `dialog.SearchValue = ...`, `dialog.DialogSize = ...`, `dialog.DialogType = ...`, `dialog.DialogPermission = ...`, `dialog.preItems = ...`) **are preserved as compatibility shims** that route to the camelCase methods. Existing callers (notably `IdevsSearchButtonEditor.openDialog`, which still writes by assignment per the PowerACC dialog interface contract) continue to work unchanged. Subclass overrides of the camelCase methods take effect through either entry point.
+- Legacy **PascalCase assignment setters** (`dialog.FilterKeys = ...`, `dialog.CriteriaKeys = ...`, `dialog.SearchValue = ...`, `dialog.DialogSize = ...`, `dialog.DialogType = ...`, `dialog.DialogPermission = ...`, `dialog.preItems = ...`) **are preserved as compatibility shims** that route to the camelCase methods. Existing callers continue to work unchanged. Subclass overrides of the camelCase methods take effect through either entry point.
 - New consumer code should prefer the camelCase methods. The PascalCase shims are not deprecated in this release but may be in a future major bump — track via the project changelog.
 - `IdevsInlineDialog.IdevsCustomButton.style` and `IdevsInlineDialog.IdevsEmptyField.style` no longer accept a raw CSS-string variant (CSS-injection vector) — use `Partial<CSSStyleDeclaration>` only.
-- `CsiPanel.PanelTitle` / `CsiPanel.Fields` getters/setters → `IdevsPanel.title` + `IdevsPanel.setTitle()` + `IdevsPanel.getFields()` + `IdevsPanel.setFields()`.
-- Clone-mode marker `__csiCloneMode` → `__idevsCloneMode`. Consumers that inspect this marker directly need to migrate (rare — typically only `isCloneMode()` users).
-- `IdevsPanel`'s editor factory no longer special-cases `CsiDateEditor` for the `format: 'd/m/Y'` default. Consumers using `IdevsDateEditor` (which lives at the `@idevs/corelib/editors/idevsDateEditor` subpath because of its optional `flatpickr` peer dep) must set `format: 'd/m/Y'` explicitly in their `editorOptions`.
+- Legacy panel title/field getters and setters → `IdevsPanel.title` + `IdevsPanel.setTitle()` + `IdevsPanel.getFields()` + `IdevsPanel.setFields()`.
+- Clone-mode marker is now `__idevsCloneMode`. Consumers that inspect the old marker directly need to migrate (rare — typically only `isCloneMode()` users).
+- `IdevsPanel`'s editor factory no longer special-cases the legacy date editor for the `format: 'd/m/Y'` default. Consumers using `IdevsDateEditor` (which lives at the `@idevs/corelib/editors/idevsDateEditor` subpath because of its optional `flatpickr` peer dep) must set `format: 'd/m/Y'` explicitly in their `editorOptions`.
 
-### Hardening deltas vs PowerACC source
+### Hardening deltas vs legacy source
 
 - **Security**: XSS-safe label markup in `IdevsPanel` and `toggleInputValidateMessage` (DOM API + `textContent` + `createElement('sup')` — replaces the source's raw HTML-property writes on form labels). `IdevsOffcanvasPanel`'s titlebar copy uses `replaceChildren(cloneNode())` instead of raw markup copy.
 - **Resource hygiene**: `IdevsEntityDialog`'s `beforeunload` window listener is now stored and removed in `destroy()` (source registered without cleanup — leak across dialog lifetimes).
@@ -172,11 +240,11 @@ All in `src/panels/`, exported from the public barrel.
 ```ts
 // src/index.ts after 1.4.0
 export * from './editors'
-export * from './dialogs'    // NEW
+export * from './dialogs' // NEW
 export * from './formatters'
-export * from './panels'     // NEW
+export * from './panels' // NEW
 export * from './ui'
-export * from './helpers'    // EXTENDED — adds dialogHelpers, filterHelper, layoutHelper
+export * from './helpers' // EXTENDED — adds dialogHelpers, filterHelper, layoutHelper
 export * from './utils'
 export * from './types'
 ```
@@ -185,12 +253,12 @@ export * from './types'
 
 ### New editors
 
-- `IdevsSelfSearchButtonEditor` (decorator: `Idevs.CoreLib.IdevsSelfSearchButtonEditor`) — self-hosted search-button editor that fetches results via Serenity's `serviceCall` and renders them in an in-editor modal or dropdown. No separately-registered Serenity search dialog required. Replaces PowerACC's `SelfSearchButtonEditor`.
-- `SlickSelfSearchButtonEditor` — SleekGrid column adapter wrapping `IdevsSelfSearchButtonEditor`. Replaces PowerACC's `SlickSelfSearchButtonEditor`.
+- `IdevsSelfSearchButtonEditor` (decorator: `Idevs.CoreLib.IdevsSelfSearchButtonEditor`) — self-hosted search-button editor that fetches results via Serenity's `serviceCall` and renders them in an in-editor modal or dropdown. No separately-registered Serenity search dialog required.
+- `SlickSelfSearchButtonEditor` — SleekGrid column adapter wrapping `IdevsSelfSearchButtonEditor`.
 
 ### New options
 
-- `presentation: 'modal' | 'dropdown'` (default: `'modal'`) — selects the in-editor result UI. The PowerACC source had two parallel code paths for these; in this port they're separate controllers (`SearchModalController` + `SearchDropdownController`) selected at construction time. Switching mid-life is NOT supported.
+- `presentation: 'modal' | 'dropdown'` (default: `'modal'`) — selects the in-editor result UI. The two presentation modes are implemented as separate controllers (`SearchModalController` + `SearchDropdownController`) selected at construction time. Switching mid-life is NOT supported.
 
 ### Breaking API renames (same as 1.2.0 for SearchButtonEditor)
 
@@ -198,7 +266,7 @@ export * from './types'
 - `editor.CriteriaKeys = [...]` → `editor.setCriteriaKeys([...])`
 - `editor.setFilterValue(key, value)` is kept from the source unchanged.
 
-### Hardening deltas vs PowerACC source
+### Hardening deltas vs legacy source
 
 - Decomposed from a single 3,404-LOC file into focused modules:
   - `src/editors/selfSearch/columnFormatters.ts` — pure parsing + built-in formatters.
@@ -218,26 +286,45 @@ export * from './types'
 - Result rows are not virtualized. Source caps via `maxResultsToShow`; large result sets render all rows to DOM (mirrors source behavior).
 - The modal and dropdown controllers intentionally retain ~40% duplicated table/keyboard/sort logic. A follow-up extraction (`selfSearch/resultsTable.ts`) is tracked separately to avoid premature consolidation.
 
-## 1.1.x → 1.2.0 — batch 3a search-button editor foundation
+## 1.1.x → 1.2.0 — batch 2 editors + batch 3a search-button editor foundation
 
 ### New editors
 
-- `IdevsSearchButtonEditor` (decorator: `Idevs.CoreLib.IdevsSearchButtonEditor`) — hidden input + display input + search/clear buttons + Serenity dialog integration. Replaces PowerACC's `SearchButtonEditor`.
-- `IdevsNumericTagEditor` (decorator: `Idevs.CoreLib.IdevsNumericTagEditor`) — extends `IdevsTagEditor` with prefix/suffix/specialValues formatting. Replaces PowerACC's `NumericTagEditor`.
-- `SlickEditorBase` (no decorator — SleekGrid column-editor base, not a Serenity widget) — abstract base for SleekGrid column editors wrapping a Serenity widget. Replaces PowerACC's `SlickEditorBase`.
-- `SlickSearchButtonEditor` — SleekGrid column adapter wrapping `IdevsSearchButtonEditor`. Replaces PowerACC's `SlickSearchButtonEditor`.
+- `IdevsTagEditor` (decorator: `Idevs.CoreLib.IdevsTagEditor`) — tag/autocomplete input with listbox suggestions, casing options, placeholder support, required validation, read-only mode, and keyboard navigation.
+- `IdevsDateEditor` (decorator: `Idevs.CoreLib.IdevsDateEditor`) — Serenity `DateEditor` wrapper with user-format display and ISO `yyyy-MM-dd` values. This editor is available only from the optional subpath because it depends on `flatpickr`:
+  ```ts
+  import { IdevsDateEditor } from '@idevs/corelib/editors/idevsDateEditor'
+  ```
+- `IdevsSearchButtonEditor` (decorator: `Idevs.CoreLib.IdevsSearchButtonEditor`) — hidden input + display input + search/clear buttons + Serenity dialog integration.
+- `IdevsNumericTagEditor` (decorator: `Idevs.CoreLib.IdevsNumericTagEditor`) — extends `IdevsTagEditor` with prefix/suffix/specialValues formatting.
+- `SlickEditorBase` (no decorator — SleekGrid column-editor base, not a Serenity widget) — abstract base for SleekGrid column editors wrapping a Serenity widget.
+- `SlickSearchButtonEditor` — SleekGrid column adapter wrapping `IdevsSearchButtonEditor`.
+
+### Optional peer dependency: `flatpickr`
+
+`IdevsDateEditor` is intentionally not re-exported from
+`@idevs/corelib/editors` or the root barrel. Consumers who never use the date
+editor do not need `flatpickr`; consumers who do use it must import the subpath
+above and ensure `flatpickr` is resolvable in their app.
 
 ### Breaking API renames
 
-- `IdevsSearchButtonEditor` ports the PowerACC API but renames two PascalCase setters to camelCase methods:
+- `IdevsSearchButtonEditor` renames two legacy PascalCase setters to camelCase methods:
   - `editor.filterKeys = {...}` (asymmetric setter) → `editor.setFilterKeys({...})`
   - `editor.CriteriaKeys = [...]` (PascalCase asymmetric setter) → `editor.setCriteriaKeys([...])`
 - Consumers using `editorParams` to configure these are unaffected.
 - `SlickEditorBase`'s `TEditor` generic is now constrained by `SlickWrappedEditor` (must expose `domNode: HTMLElement`; `value?`, `destroy?`, `props?` are optional). Subclasses wrapping editors that lack those shapes need to declare them.
 - `SlickEditorBase.validate()` now returns `{ valid: boolean; msg?: string }` (matching SleekGrid's `ValidationResult`) instead of `{ valid: boolean; msg: string | null }`. The optional-property form is compatible with the source semantics but TypeScript callers comparing `msg === null` need to compare `msg === undefined`.
 
-### Hardening deltas vs PowerACC source
+### Hardening deltas vs legacy source
 
+- `IdevsTagEditor` uses ARIA combobox/listbox roles, stable option IDs,
+  document-click cleanup, related-target blur handling, and a single
+  `set_value()` chokepoint so casing and validation stay consistent.
+- `IdevsDateEditor` keeps the hidden source input in ISO format, syncs
+  validation classes to flatpickr's visible alt input, places calendars inside
+  active modals when needed, and tears down mutation/keyboard handlers in
+  `destroy()`.
 - XSS-safe required marker via `document.createElement('sup')` + `textContent` (no raw HTML-property writes on labels — same fix pattern as the 1.1.0 `DropdownToolButton` audit).
 - WAI-ARIA combobox role on the display input (`role="combobox"`, `aria-autocomplete="list"`, `aria-haspopup="dialog"`, `aria-expanded`, `aria-required`).
 - Single-chokepoint value writes — every `domNode.value` mutation routes through `set_value()`.
@@ -250,11 +337,11 @@ export * from './types'
 
 ### Recommended migration
 
-Replace direct PowerACC imports:
+Replace direct legacy imports:
 
 ```ts
 // before
-import { SearchButtonEditor } from 'PowerACC/Modules/Csi'
+import { SearchButtonEditor } from 'legacy-app'
 
 // after
 import { IdevsSearchButtonEditor } from '@idevs/corelib/editors'
@@ -373,13 +460,13 @@ of items deprecated in 1.1.0.
 
 ### Compatibility direction
 
-| | 1.x lane (current) | 2.x lane (future) |
-|---|---|---|
-| `Idevs.Net.CoreLib` | 0.7.x | 0.8+ (planned) |
-| .NET TFM | `net8.0` | `net10.0` |
-| `Serenity.Net.Services` | `8.8.9` | `10.x` |
-| `@serenity-is/corelib` | `>=8.8.6 <9` | `>=10.0.0 <11` |
-| Visual Studio | 2022 | 2026 |
+|                         | 1.x lane (current) | 2.x lane (future) |
+| ----------------------- | ------------------ | ----------------- |
+| `Idevs.Net.CoreLib`     | 0.7.x              | 0.8+ (planned)    |
+| .NET TFM                | `net8.0`           | `net10.0`         |
+| `Serenity.Net.Services` | `8.8.9`            | `10.x`            |
+| `@serenity-is/corelib`  | `>=8.8.6 <9`       | `>=10.0.0 <11`    |
+| Visual Studio           | 2022               | 2026              |
 
 Serenity 9.x is intentionally skipped — the project follows Serenity's own
 ".NET 8 stays on the 8.x lane; .NET 10 moves to 10.x" guidance.
@@ -387,10 +474,12 @@ Serenity 9.x is intentionally skipped — the project follows Serenity's own
 ### Planned 2.0.0 changes
 
 **Deprecation removals (from 1.1.0):**
+
 - Remove `IdevsContentResponse.FileName` (use `DownloadName`).
 - Remove implicit `import './globals'` from the root entry (use the subpath).
 
 **Wire-contract alignment with .NET DTOs:**
+
 - Rename camelCase wire fields to PascalCase to match the .NET DTO:
   `viewName` → `ViewName`, `companyName` → `CompanyName`,
   `reportName` → `ReportName`, `selectionRange` → `SelectionRange`,
@@ -400,6 +489,7 @@ Serenity 9.x is intentionally skipped — the project follows Serenity's own
   wire DTO) — they remain on `PdfExportOptions` (the client-side options type).
 
 **Serenity 10 modernization:**
+
 - Replace `@Decorators.registerEditor(...)` / `@Decorators.registerFormatter(...)`
   / `@Decorators.option()` with `static [Symbol.typeInfo] = this.registerClass(...)`
   in every editor and formatter (Serenity 9+ deprecated decorator registration).
@@ -412,6 +502,7 @@ Serenity 9.x is intentionally skipped — the project follows Serenity's own
   `tsconfig.types`.
 
 **General cleanup:**
+
 - Enable full TypeScript strict mode.
 - Consider dropping CommonJS in favor of ESM-only, aligned with the modern
   Serenity 10 toolchain.

--- a/README.md
+++ b/README.md
@@ -3,14 +3,15 @@
 ![npm version](https://img.shields.io/npm/v/@idevs/corelib.svg)
 ![license](https://img.shields.io/npm/l/@idevs/corelib.svg)
 
-A comprehensive library of extended components and utilities for the Serenity Framework. This library provides additional editors, formatters, UI components, and helper functions to enhance your Serenity applications.
+A comprehensive library of extended components and utilities for the Serenity Framework. This library provides additional editors, formatters, dialogs, panels, grids, UI components, and helper functions to enhance Serenity applications.
 
 ## Features
 
-- 🎛️ **Extended Editors**: Additional input editors like CheckboxButton and DateMonth
+- 🎛️ **Extended Editors**: Checkbox, date, tag, numeric tag, search-button, and self-search editors
 - 📊 **Custom Formatters**: Specialized data formatters for grids and displays
+- 🧩 **Dialogs, Panels, and Grids**: Serenity building blocks with hardened lifecycle and validation behavior
 - 🎨 **UI Components**: Enhanced toolbar buttons and UI widgets
-- 🛠️ **Utility Functions**: Date, DOM, and formatting utilities
+- 🛠️ **Utility Functions**: Date, DOM, layout, dialog, filter, and formatting utilities
 - 📄 **Export Helpers**: PDF and Excel export functionality
 - 🌐 **TypeScript**: Full TypeScript support with type definitions
 
@@ -25,12 +26,14 @@ npm install @idevs/corelib
 `@idevs/corelib` ships against the following peers, declared in your app's
 `package.json`:
 
-| Package | Range | Required |
-|---|---|---|
-| `@serenity-is/corelib` | `>=8.8.6 <9` | yes |
-| `@serenity-is/sleekgrid` | `>=1.9.6 <2` | yes |
-| `jquery` | `>=3.5` | optional (used by UI helpers) |
-| `jspdf` | `>=3` | optional (used by PDF helpers) |
+| Package                   | Range        | Required                                           |
+| ------------------------- | ------------ | -------------------------------------------------- |
+| `@serenity-is/corelib`    | `>=8.8.6 <9` | yes                                                |
+| `@serenity-is/sleekgrid`  | `>=1.9.6 <2` | yes                                                |
+| `@serenity-is/extensions` | `>=8.7 <11`  | optional (used by selectable/grid-editor subpaths) |
+| `flatpickr`               | `>=4.6 <5`   | optional (used by `IdevsDateEditor`)               |
+| `jquery`                  | `>=3.5`      | optional (used by UI helpers)                      |
+| `jspdf`                   | `>=3`        | optional (used by PDF helpers)                     |
 
 ### Compatibility matrix
 
@@ -39,10 +42,10 @@ companion [Idevs.Net.CoreLib](https://www.nuget.org/packages/Idevs.Net.CoreLib).
 Serenity 9.x is intentionally skipped — pick the lane that matches your
 target framework:
 
-| Lane | `Idevs.Net.CoreLib` | .NET TFM | `Serenity.Net.Services` | `@serenity-is/corelib` | `@idevs/corelib` |
-|---|---|---|---|---|---|
-| **Current** | 0.7.x | `net8.0` | `8.8.9` | `>=8.8.6 <9` | **1.x** |
-| **Future** | 0.8+ (planned) | `net10.0` | `10.x` | `>=10.0.0 <11` | **2.x** (planned) |
+| Lane        | `Idevs.Net.CoreLib` | .NET TFM  | `Serenity.Net.Services` | `@serenity-is/corelib` | `@idevs/corelib`  |
+| ----------- | ------------------- | --------- | ----------------------- | ---------------------- | ----------------- |
+| **Current** | 0.7.x               | `net8.0`  | `8.8.9`                 | `>=8.8.6 <9`           | **1.x**           |
+| **Future**  | 0.8+ (planned)      | `net10.0` | `10.x`                  | `>=10.0.0 <11`         | **2.x** (planned) |
 
 The TS DTOs in `@idevs/corelib/types/export` mirror the .NET `Idevs.Models.*`
 DTOs; see [MIGRATION.md](./MIGRATION.md) for naming changes between versions.
@@ -105,6 +108,25 @@ After installing, update your `tsconfig.json`:
 
 ### Editors
 
+Most editors are available from the root entry or the editors barrel:
+
+```typescript
+import {
+  IdevsTagEditor,
+  IdevsNumericTagEditor,
+  IdevsSearchButtonEditor,
+  IdevsSelfSearchButtonEditor,
+  SlickSearchButtonEditor,
+  SlickSelfSearchButtonEditor,
+} from '@idevs/corelib'
+```
+
+`IdevsDateEditor` is subpath-only because `flatpickr` is optional:
+
+```typescript
+import { IdevsDateEditor } from '@idevs/corelib/editors/idevsDateEditor'
+```
+
 #### CheckboxButtonEditor
 
 A multi-checkbox editor that displays options as button-style checkboxes.
@@ -118,6 +140,28 @@ export class MyForm extends EntityDialog {
     }),
   }
 }
+```
+
+### Dialogs, Panels, and Grids
+
+```typescript
+import {
+  IdevsEntityDialog,
+  IdevsInlineDialog,
+  IdevsPanel,
+  IdevsTabControl,
+  IdevsEntityGrid,
+  IdevsSearchGrid,
+  IdevsGridEditController,
+} from '@idevs/corelib'
+```
+
+The selectable/grid-editor bases depend on Serenity's optional
+`@serenity-is/extensions` package and are exposed through subpaths:
+
+```typescript
+import { IdevsSelectableEntityGrid } from '@idevs/corelib/grids/idevsSelectableEntityGrid'
+import { IdevsGridEditorBase } from '@idevs/corelib/grids/idevsGridEditorBase'
 ```
 
 ### Formatters
@@ -225,6 +269,12 @@ const toolButton = createExportToolButton(exportOptions)
 ## Migration Guide
 
 If you're upgrading from an earlier version:
+
+### Upgrading from 1.1.1 to 1.5.0
+
+Version 1.5.0 adds editors, dialogs, panels, grids, and helpers. Existing 1.1.1
+consumers should review [MIGRATION.md](./MIGRATION.md), especially optional peer
+dependencies, subpath-only imports, and legacy-to-`Idevs*` API renames.
 
 ### Breaking Changes in v1.0.0
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -6,7 +6,7 @@ import prettierConfig from 'eslint-config-prettier'
 export default [
   // Base ESLint recommended rules
   js.configs.recommended,
-  
+
   // TypeScript files configuration
   {
     files: ['src/**/*.{ts,tsx}'],
@@ -92,32 +92,35 @@ export default [
       // TypeScript enum members, overload params, and ambient declarations
       // correctly (the base rule does not).
       'no-unused-vars': 'off',
-      '@typescript-eslint/no-unused-vars': ['error', {
-        argsIgnorePattern: '^_',
-        varsIgnorePattern: '^_',
-        ignoreRestSiblings: true,
-      }],
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          argsIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+          ignoreRestSiblings: true,
+        },
+      ],
       '@typescript-eslint/consistent-type-definitions': ['error', 'type'],
       '@typescript-eslint/no-explicit-any': 'warn',
       'prefer-const': 'error',
       'no-var': 'error',
-      'no-console': 'warn',
-      'eqeqeq': ['error', 'always', { null: 'ignore' }],
+      'no-console': ['warn', { allow: ['warn', 'error', 'info'] }],
+      eqeqeq: ['error', 'always', { null: 'ignore' }],
       'no-undef': 'error',
       'no-useless-escape': 'error',
     },
   },
-  
+
   // Prettier configuration (disables conflicting rules)
   prettierConfig,
-  
+
   // Global ignores
   {
     ignores: [
       'dist/',
       'node_modules/',
       '*.js',
-      'eslint.config.js', // Ignore this config file itself
+      'eslint.config.mjs', // Ignore this config file itself
     ],
   },
 ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@idevs/corelib",
-  "version": "1.1.1",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@idevs/corelib",
-      "version": "1.1.1",
+      "version": "1.5.0",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.33.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@idevs/corelib",
-  "version": "1.1.1",
+  "version": "1.5.0",
   "description": "Extended library components and utilities for Serenity Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/grids/idevsGridEditController.ts
+++ b/src/grids/idevsGridEditController.ts
@@ -268,24 +268,24 @@ export class IdevsGridEditController<
     if (this.editable) {
       if (this.autoEdit) {
         this.subscribe(this.grid.slickGrid.onClick as unknown as SlickEventEmitter, (e, args) =>
-          this.loadEditorForCell(args),
+          this.loadEditorForCell(args)
         )
       } else {
         this.subscribe(this.grid.slickGrid.onDblClick as unknown as SlickEventEmitter, (e, args) =>
-          this.loadEditorForCell(args),
+          this.loadEditorForCell(args)
         )
       }
     }
     this.subscribe(
       this.grid.slickGrid.onActiveCellChanged as unknown as SlickEventEmitter,
-      (e, args) => this.handleActiveCellChanged(e, args),
+      (e, args) => this.handleActiveCellChanged(e, args)
     )
     this.subscribe(this.grid.slickGrid.onKeyDown as unknown as SlickEventEmitter, (e, args) =>
-      this.handleKeyDown(e as unknown as KeyboardEvent, args),
+      this.handleKeyDown(e as unknown as KeyboardEvent, args)
     )
     this.subscribe(
       this.grid.slickGrid.onActiveCellPositionChanged as unknown as SlickEventEmitter,
-      (_e, args) => this.handleActiveCellPositionChanged(args),
+      (_e, args) => this.handleActiveCellPositionChanged(args)
     )
   }
 
@@ -330,7 +330,6 @@ export class IdevsGridEditController<
         // which is a real bug worth surfacing — but we still want to drain
         // remaining subscriptions during teardown. Matches the sibling
         // pattern in IdevsGridEditorBase.cleanupEventListeners().
-        // eslint-disable-next-line no-console -- traceability for teardown bugs
         console.warn('[IdevsGridEditController] subscription teardown threw:', error)
       }
     }
@@ -340,7 +339,7 @@ export class IdevsGridEditController<
 
   private subscribe(
     emitter: SlickEventEmitter,
-    handler: (e: IEventData, args: ArgsCell) => unknown,
+    handler: (e: IEventData, args: ArgsCell) => unknown
   ): void {
     emitter.subscribe(handler)
     this.subscriptions.push({ emitter, handler })
@@ -460,14 +459,14 @@ export class IdevsGridEditController<
       this.enterKey = true
       const notifyArgs = { ...args, row, cell }
       ;(this.grid.slickGrid.onActiveCellChanged as unknown as SlickEventEmitter).notify(
-        notifyArgs as ArgsCell,
+        notifyArgs as ArgsCell
       )
       args.row = row
       args.cell = cell
     } catch (err) {
       console.warn(
         '[IdevsGridEditController] handleKeyDown threw — keystroke navigation aborted:',
-        err,
+        err
       )
       this.enterKey = false
     }
@@ -551,7 +550,7 @@ export class IdevsGridEditController<
       // iterating — behavior unchanged — but devs now have a trail.
       console.warn(
         '[IdevsGridEditController] findColumnByDataId: header data-id matches no visible column id or field:',
-        dataId,
+        dataId
       )
     }
     return idx
@@ -582,13 +581,8 @@ export class IdevsGridEditController<
     // Same-cell re-activation (currentRow === args.row && currentCell
     // === args.cell) is NOT a cleanup case — the controller-managed
     // toggle-off in `loadEditor` handles that flow.
-    const isDifferentCell =
-      this.currentRow !== args.row || this.currentCell !== args.cell
-    if (
-      this.currentCell !== null &&
-      this.currentRow !== null &&
-      isDifferentCell
-    ) {
+    const isDifferentCell = this.currentRow !== args.row || this.currentCell !== args.cell
+    if (this.currentCell !== null && this.currentRow !== null && isDifferentCell) {
       const slickCell = this.grid.slickGrid.getCellNode(this.currentRow, this.currentCell)
       if (slickCell) {
         // Marker-based lookup (NOT `firstElementChild + s-*Editor regex`).
@@ -644,7 +638,7 @@ export class IdevsGridEditController<
     } catch (notifyErr) {
       console.warn(
         '[IdevsGridEditController] onCellChange subscriber threw; editor state already committed:',
-        notifyErr,
+        notifyErr
       )
     }
   }
@@ -659,7 +653,7 @@ export class IdevsGridEditController<
   private getCellValue(item: unknown, column: GridColumn): unknown {
     return this.grid.slickGrid.getDataItemValueForColumn(
       item,
-      column as unknown as Parameters<typeof this.grid.slickGrid.getDataItemValueForColumn>[1],
+      column as unknown as Parameters<typeof this.grid.slickGrid.getDataItemValueForColumn>[1]
     )
   }
 
@@ -692,11 +686,10 @@ export class IdevsGridEditController<
     // assertion.
     if (!hasField(column)) {
       // Misconfiguration signal: an editable column with no `field` is
-      // unusable. Log under the project's project-wide `no-console: warn`
-      // policy so consumers can find the offending column descriptor.
+      // unusable. Warn so consumers can find the offending column descriptor.
       console.warn(
         '[IdevsGridEditController] Column has editorType but no field; ignoring edit',
-        column,
+        column
       )
       return
     }
@@ -812,9 +805,7 @@ export class IdevsGridEditController<
     const children = target.children
     for (let i = 0; i < children.length; i++) {
       const child = children[i] as HTMLElement
-      if (
-        child.getAttribute(IdevsGridEditController.EDITOR_MARKER_ATTR) === 'true'
-      ) {
+      if (child.getAttribute(IdevsGridEditController.EDITOR_MARKER_ATTR) === 'true') {
         return child
       }
     }
@@ -919,7 +910,7 @@ export class IdevsGridEditController<
       // through `IdevsGridEditControllerOptions`.
       const formattedValue = (Number.isFinite(numericValue) ? numericValue : 0).toLocaleString(
         'en-US',
-        { minimumFractionDigits: 2, maximumFractionDigits: 2 },
+        { minimumFractionDigits: 2, maximumFractionDigits: 2 }
       )
       // XSS hardening: textContent (source used innerHTML, fine for
       // numeric output but consistent with the rest of the editors).
@@ -949,9 +940,7 @@ export class IdevsGridEditController<
     // No `isReadonlyCell(args.cell)` either — loadEditor filters
     // readOnly columns via `column.sourceItem.readOnly` BEFORE dispatch.
     const toggleTarget =
-      target.tagName.toLowerCase() === 'span'
-        ? target
-        : target.querySelector<HTMLElement>('span')
+      target.tagName.toLowerCase() === 'span' ? target : target.querySelector<HTMLElement>('span')
     if (!toggleTarget) return
     toggleTarget.classList.toggle('checked')
     item[column.field] = toggleTarget.classList.contains('checked')
@@ -972,9 +961,11 @@ export class IdevsGridEditController<
       this.appendEditorChild(target, container)
       target.classList.add('text-white')
     }
-    ;(lookupEditor as unknown as {
-      changeSelect2: (handler: (e: Select2Event) => void) => void
-    }).changeSelect2(e => {
+    ;(
+      lookupEditor as unknown as {
+        changeSelect2: (handler: (e: Select2Event) => void) => void
+      }
+    ).changeSelect2(e => {
       const val = e.originalEvent.val
       item[column.field] = val
       // Round-11 #3 (Copilot): when the Select2 commit replaces the
@@ -1009,9 +1000,11 @@ export class IdevsGridEditController<
     if (container) {
       this.appendEditorChild(target, container)
     }
-    ;(serviceLookupEditor as unknown as {
-      changeSelect2: (handler: (e: Select2Event) => void) => void
-    }).changeSelect2(e => {
+    ;(
+      serviceLookupEditor as unknown as {
+        changeSelect2: (handler: (e: Select2Event) => void) => void
+      }
+    ).changeSelect2(e => {
       const originalEvent = e.originalEvent
       const addedSource = originalEvent.added?.source
       item[column.field] = originalEvent.val
@@ -1036,9 +1029,7 @@ export class IdevsGridEditController<
       // otherwise fall back to the committed val (the id).
       // Consumers wanting a different display format can override
       // via a custom registered renderer.
-      const textField = (editorParams as Record<string, unknown>).textField as
-        | string
-        | undefined
+      const textField = (editorParams as Record<string, unknown>).textField as string | undefined
       const displayValue =
         addedSource && textField && textField in addedSource
           ? addedSource[textField]

--- a/src/grids/idevsGridEditorBase.ts
+++ b/src/grids/idevsGridEditorBase.ts
@@ -115,7 +115,7 @@ export class IdevsGridEditorBase<TEntity, P = unknown> extends GridEditorBase<TE
     oldRow: number,
     newRow: number,
     oldItem: TEntity,
-    newItem: TEntity,
+    newItem: TEntity
   ) => void)[] = []
   private readonly _addButtonClickSubscribers: (() => void)[] = []
 
@@ -208,7 +208,7 @@ export class IdevsGridEditorBase<TEntity, P = unknown> extends GridEditorBase<TE
         if (isCloneError) {
           console.warn(
             '[IdevsGridEditorBase] getDeletedRows: structuredClone failed (non-cloneable TEntity?); returning shallow copy:',
-            cloneErr,
+            cloneErr
           )
           return [...this._deletedRows]
         }
@@ -248,7 +248,7 @@ export class IdevsGridEditorBase<TEntity, P = unknown> extends GridEditorBase<TE
     // and return a no-op unsubscribe so the caller has a clear signal.
     if (this._destroyed) {
       console.warn(
-        '[IdevsGridEditorBase] subscribeToAddButtonClick called after destroy() — callback will never fire',
+        '[IdevsGridEditorBase] subscribeToAddButtonClick called after destroy() — callback will never fire'
       )
       return () => undefined
     }
@@ -260,12 +260,12 @@ export class IdevsGridEditorBase<TEntity, P = unknown> extends GridEditorBase<TE
   }
 
   public subscribeToRowChange(
-    callback: (oldRow: number, newRow: number, oldItem: TEntity, newItem: TEntity) => void,
+    callback: (oldRow: number, newRow: number, oldItem: TEntity, newItem: TEntity) => void
   ): () => void {
     // See subscribeToAddButtonClick for the post-destroy rationale.
     if (this._destroyed) {
       console.warn(
-        '[IdevsGridEditorBase] subscribeToRowChange called after destroy() — callback will never fire',
+        '[IdevsGridEditorBase] subscribeToRowChange called after destroy() — callback will never fire'
       )
       return () => undefined
     }
@@ -283,7 +283,6 @@ export class IdevsGridEditorBase<TEntity, P = unknown> extends GridEditorBase<TE
       } catch (error) {
         // Subscriber callbacks are consumer code; log + continue so one
         // bad subscriber doesn't break the whole notify cycle.
-        // eslint-disable-next-line no-console
         console.warn('[IdevsGridEditorBase] add-button-click subscriber threw:', error)
       }
     }
@@ -293,13 +292,12 @@ export class IdevsGridEditorBase<TEntity, P = unknown> extends GridEditorBase<TE
     oldRow: number,
     newRow: number,
     oldItem: TEntity,
-    newItem: TEntity,
+    newItem: TEntity
   ): void {
     for (const cb of this._rowChangeSubscribers) {
       try {
         cb(oldRow, newRow, oldItem, newItem)
       } catch (error) {
-        // eslint-disable-next-line no-console
         console.warn('[IdevsGridEditorBase] row-change subscriber threw:', error)
       }
     }
@@ -506,7 +504,7 @@ export class IdevsGridEditorBase<TEntity, P = unknown> extends GridEditorBase<TE
           }
         }
         return true
-      },
+      }
     )
 
     // Track row changes for the row-change subscribers.
@@ -528,13 +526,13 @@ export class IdevsGridEditorBase<TEntity, P = unknown> extends GridEditorBase<TE
           this._currentActiveRow = newRow
         }
         this._lastValidationFailed = false
-      },
+      }
     )
 
     // Click / dblClick depending on autoEdit.
-    const clickEmitter = (
-      this._opts.autoEdit ? this.slickGrid.onClick : this.slickGrid.onDblClick
-    ) as unknown as SlickEventEmitter
+    const clickEmitter = (this._opts.autoEdit
+      ? this.slickGrid.onClick
+      : this.slickGrid.onDblClick) as unknown as SlickEventEmitter
     const clickEventName = this._opts.autoEdit ? 'onClick' : 'onDblClick'
     this.addEventListener(clickEmitter, clickEventName, (e, args) => {
       if (this.readOnly) {
@@ -604,7 +602,7 @@ export class IdevsGridEditorBase<TEntity, P = unknown> extends GridEditorBase<TE
     this.addEventListener(
       this.slickGrid.onKeyDown as unknown as SlickEventEmitter,
       'onKeyDown',
-      this.handleKeyDown,
+      this.handleKeyDown
     )
   }
 
@@ -616,7 +614,7 @@ export class IdevsGridEditorBase<TEntity, P = unknown> extends GridEditorBase<TE
   protected addEventListener(
     target: SlickEventEmitter | EventTarget | undefined,
     eventName: string,
-    handler: (e: AddListenerEvent, args: ArgsCell | undefined) => unknown,
+    handler: (e: AddListenerEvent, args: ArgsCell | undefined) => unknown
   ): void {
     if (target && typeof (target as SlickEventEmitter).subscribe === 'function') {
       const emitter = target as SlickEventEmitter
@@ -676,7 +674,7 @@ export class IdevsGridEditorBase<TEntity, P = unknown> extends GridEditorBase<TE
     // open an editor on a column that shouldn't be edited.
     const columns = this.slickGrid.getColumns() as unknown as GridColumnArr
     const firstEditableCell = columns.findIndex((_col, idx) =>
-      this.isCellEditable(row, idx, columns),
+      this.isCellEditable(row, idx, columns)
     )
     this.slickGrid.setActiveCell(row, firstEditableCell > -1 ? firstEditableCell : 0)
     this.slickGrid.scrollRowIntoView(row, true)
@@ -704,7 +702,7 @@ export class IdevsGridEditorBase<TEntity, P = unknown> extends GridEditorBase<TE
     } catch (err) {
       console.warn(
         '[IdevsGridEditorBase] deleteCurrentRow: view.deleteItem failed; row NOT added to deletedRows:',
-        err,
+        err
       )
       throw err
     }
@@ -729,10 +727,10 @@ export class IdevsGridEditorBase<TEntity, P = unknown> extends GridEditorBase<TE
     } catch (repaintErr) {
       console.warn(
         '[IdevsGridEditorBase] deleteCurrentRow: repaint after deleteItem threw; data deleted but grid may be stale:',
-        repaintErr,
+        repaintErr
       )
       notifyError(
-        'The row was deleted but the grid display could not be refreshed. Please reload to see the current state.',
+        'The row was deleted but the grid display could not be refreshed. Please reload to see the current state.'
       )
       return
     }
@@ -759,7 +757,10 @@ export class IdevsGridEditorBase<TEntity, P = unknown> extends GridEditorBase<TE
     const currentRow = activeCell.row
     const targetRow = currentRow + delta
 
-    const data = this.slickGrid.getData() as { getItems(): TEntity[]; setItems(items: TEntity[]): void }
+    const data = this.slickGrid.getData() as {
+      getItems(): TEntity[]
+      setItems(items: TEntity[]): void
+    }
     const items = data.getItems()
     if (delta < 0 && currentRow <= 0) return
     if (delta > 0 && currentRow >= items.length - 1) return
@@ -1117,7 +1118,7 @@ export class IdevsGridEditorBase<TEntity, P = unknown> extends GridEditorBase<TE
       committed = lock.commitCurrentEdit()
     } catch (commitError) {
       // Surface programmer/runtime commit failures so the user-data-lost
-      // scenario is traceable. Project policy: `no-console: warn`.
+      // scenario is traceable.
       console.warn('[IdevsGridEditorBase] commitCurrentEdit threw:', commitError)
       this.slickGrid.getEditorLock().cancelCurrentEdit()
       notifyError('Unable to save the cell value. Please try again.')
@@ -1182,7 +1183,6 @@ export class IdevsGridEditorBase<TEntity, P = unknown> extends GridEditorBase<TE
       try {
         cleanup()
       } catch (error) {
-        // eslint-disable-next-line no-console
         console.warn('[IdevsGridEditorBase] event cleanup threw:', error)
       }
     }
@@ -1226,7 +1226,7 @@ type GridColumnArr = GridColumn[]
  * into stale assertions.
  */
 function isDefinedCellTarget(
-  args: ArgsCell | undefined,
+  args: ArgsCell | undefined
 ): args is ArgsCell & { row: number; cell: number } {
   return !!args && args.row !== undefined && args.cell !== undefined
 }

--- a/src/grids/idevsSearchGrid.ts
+++ b/src/grids/idevsSearchGrid.ts
@@ -393,7 +393,7 @@ export abstract class IdevsSearchGrid<TRow, P = unknown> extends IdevsEntityGrid
       // diagnostics. Consumers wanting a user-visible signal can
       // override `editItem` directly.
       console.info(
-        `[IdevsSearchGrid] editItem(${String(entityOrId)}) denied: permission '${this._editPermission}' not granted`,
+        `[IdevsSearchGrid] editItem(${String(entityOrId)}) denied: permission '${this._editPermission}' not granted`
       )
       return
     }
@@ -431,7 +431,7 @@ export abstract class IdevsSearchGrid<TRow, P = unknown> extends IdevsEntityGrid
         // handler to the same microtask hop, ensuring no transient
         // unhandled-rejection event fires for chunk-load / dynamic-import
         // failures on a code-split dialog module.
-        err => this.safeHandleEditItemError(err, entityOrId, 'dialog-load'),
+        err => this.safeHandleEditItemError(err, entityOrId, 'dialog-load')
       )
       return
     }
@@ -451,7 +451,7 @@ export abstract class IdevsSearchGrid<TRow, P = unknown> extends IdevsEntityGrid
   private safeHandleEditItemError(
     err: unknown,
     entityOrId: string | number,
-    phase: 'dialog-load' | 'dialog-open',
+    phase: 'dialog-load' | 'dialog-open'
   ): void {
     try {
       this.handleEditItemError(err, entityOrId, phase)
@@ -461,7 +461,7 @@ export abstract class IdevsSearchGrid<TRow, P = unknown> extends IdevsEntityGrid
       // become an unhandled-rejection event in the .then callback path).
       console.warn(
         `[IdevsSearchGrid] handleEditItemError override threw (phase=${phase}):`,
-        handlerErr,
+        handlerErr
       )
       // The fallback notifyError is ALSO wrapped — if Serenity's toast
       // path itself throws (detached container, consumer monkey-patch),
@@ -472,7 +472,7 @@ export abstract class IdevsSearchGrid<TRow, P = unknown> extends IdevsEntityGrid
       } catch (notifyErr) {
         console.warn(
           '[IdevsSearchGrid] notifyError fallback also threw — no user-visible signal possible:',
-          notifyErr,
+          notifyErr
         )
       }
     }
@@ -503,7 +503,7 @@ export abstract class IdevsSearchGrid<TRow, P = unknown> extends IdevsEntityGrid
     if (typeof resultThen === 'function') {
       ;(result as PromiseLike<unknown>).then(
         () => undefined,
-        err => this.safeHandleEditItemError(err, entityOrId, 'dialog-open'),
+        err => this.safeHandleEditItemError(err, entityOrId, 'dialog-open')
       )
     } else if (result !== undefined && result !== null) {
       // [Suggestion #13] Non-thenable, non-nullish return from
@@ -513,9 +513,9 @@ export abstract class IdevsSearchGrid<TRow, P = unknown> extends IdevsEntityGrid
       // without crashing the user-gesture path.
       console.warn(
         `[IdevsSearchGrid] loadByIdAndOpenDialog returned non-thenable for id=${String(
-          entityOrId,
+          entityOrId
         )}:`,
-        result,
+        result
       )
     }
   }
@@ -550,17 +550,16 @@ export abstract class IdevsSearchGrid<TRow, P = unknown> extends IdevsEntityGrid
   protected handleEditItemError(
     err: unknown,
     entityOrId: string | number,
-    phase?: 'dialog-load' | 'dialog-open',
+    phase?: 'dialog-load' | 'dialog-open'
   ): void {
     notifyError('Unable to open editor dialog.')
     // Structured warn for traceability of user-gesture-triggered dialog
-    // failures (project policy: `no-console: warn`). Consumers can
-    // override handleEditItemError to route elsewhere.
+    // failures. Consumers can override handleEditItemError to route elsewhere.
     console.warn(
       `[IdevsSearchGrid] editItem(${String(entityOrId)}) failed to open dialog${
         phase ? ` (phase=${phase})` : ''
       }:`,
-      err,
+      err
     )
   }
 


### PR DESCRIPTION
## Summary

- Bumps `package.json` from `1.1.1` to `1.5.0`, folding the unreleased batches 2-4b work into a properly versioned release
- Rewrites `CHANGELOG.md` `[Unreleased]` placeholder into a full `[1.5.0] - 2026-05-30` entry with Keep-a-Changelog Added / Changed / Fixed / Removed / Migration sections covering editor, dialog, panel, grid, helper, and hardening work
- Adds a `1.1.1 → 1.5.0` overview map at the top of `MIGRATION.md` linking the four lane-sections (`1.2.0` / `1.3.0` / `1.4.0` / `1.5.0`) with required consumer checks
- Expands `README.md` for new editors (Tag / Date / Numeric Tag / Search-Button / Self-Search), Dialogs / Panels / Grids; peer-dep table grows to include `@serenity-is/extensions` and `flatpickr` as optionals
- Migrates `eslint.config.js` → `eslint.config.mjs` (ESM), which eliminates the `[MODULE_TYPELESS_PACKAGE_JSON] Warning` and lets the `no-console: warn` rule cleanly allow telemetry `warn` / `error` / `info` — lint warnings drop from 17 → 0 without behavior change
- Reformats the three just-shipped grid sources (`idevsGridEditController.ts`, `idevsGridEditorBase.ts`, `idevsSearchGrid.ts`) via prettier (trailing-comma cleanup, redundant `eslint-disable-next-line` removal under the new rule). Verified via `git diff -w` — zero behavior change

## Release automation

Merging this PR will trigger `.github/workflows/release.yml` (`on: push: branches: [main]`):
- Reads `package.json` version (`1.5.0`)
- Confirms no `v1.5.0` tag exists yet
- Runs `npm run prepublishOnly` (typecheck + lint + test + build)
- Publishes to npm via OIDC Trusted Publishing (`--access public --provenance`, no `NPM_TOKEN` needed)
- Creates and pushes the `v1.5.0` tag
- Creates the GitHub Release with auto-generated notes

No manual tagging required.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors / 0 warnings
- [x] `npm test` — 556 passed / 1 skipped (32 test files)
- [x] `npm run build` — clean
- [x] `git diff -w` on the three grid source files — confirms pure prettier reformatting, zero behavior change
- [ ] CI on this PR — Build & Test
- [ ] Post-merge `release.yml` — pack + publish + tag + GitHub release